### PR TITLE
docs: Update project structure and crate dependencies

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -48,51 +48,50 @@ cargo xt
 
 This repository is a [Cargo workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) composed of multiple crates:
 
-### oso_kernel
+### `oso_kernel`
 
-The core kernel crate.
+The crate that constitutes the kernel body
 
-Highlights:
+**Features**
 
-- Uses many advanced nightly Rust features
-- Modular structure:
-  - app: Application runtime layer
-  - base: Core abstractions and utilities
-  - driver: Device drivers
-  - gui: Graphical user interface
-- Integrates with:
-  - oso_bridge: Interface between bootloader and kernel
-  - oso_binary_parser: Parses binary formats like DeviceTree (.dtb)
-  - oso_proc_macro: Procedural macros for code generation
-  - oso_error: Unified error handling framework
+- Extensive use of nightly Rust features
+- Module structure:
+  - `app`: Application execution system
+  - `base`: Basic library
+  - `driver`: Device control
+- Integration with other crates:
+  - `oso_no_std_shared`: Shared library for no_std environment
+  - `oso_proc_macro`: Automatic code generation through macros
+  - `oso_error`: Error handling system
 
-### oso_loader
+### `oso_loader`
 
-A custom UEFI-compliant bootloader.
+Custom UEFI-compatible bootloader implementation.
 
-- Includes chibi_uefi: a minimalist UEFI wrapper written in Rust
-- Supports ELF-based kernel loading
-- Uses:
-  - oso_bridge
-  - oso_error
+- ELF format kernel loading functionality
+- Graphics support (RGB/BGR/Bitmask formats)
+- Used crates:
+  - `oso_no_std_shared`
+  - `oso_proc_macro`
+  - `oso_error`
 
-### xtask
+### `xtask`
 
-Developer-focused CLI utilities.
+Developer auxiliary tool suite.
 
-- Builds for UEFI/QEMU environments
-- Handles boot image creation and QEMU execution
-- Automates deploy/test/dev flow
+- Build assistance for QEMU and UEFI targets
+- Startup scripts
+- Deployment and test automation processes
 
-### Supporting Crates
+### Auxiliary Crates List
 
-| クレート名             | 説明                                                                         |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `oso_binary_parser`    | Provides a general framework for parsing ELF, DeviceTree, and other binaries |
-| `oso_proc_macro_logic` | Internal logic and tests for procedural macro expansion                      |
-| `oso_proc_macro`       | Macros for generating kernel structs, parsers, and test scaffolding          |
-| `oso_error`            | Common error types and handling logic                                        |
-| `oso_bridge`           | Shared interface structures between bootloader and kernel                    |
+| Crate Name             | Description                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `oso_no_std_shared`    | Provides basic data structures and utilities shared in no_std environment     |
+| `oso_proc_macro_logic` | Internal logic implementation and testing for procedural macros               |
+| `oso_proc_macro`       | Macro suite supporting kernel struct, parser, and test generation             |
+| `oso_error`            | Common error types and error handling logic                                   |
+| `util_common_code`     | General-purpose code shared between development tools                         |
 
 ## build
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ cargo xt
   - `app`：アプリ実行系
   - `base`：基本ライブラリ
   - `driver`：デバイス制御
-  - `gui`：グラフィカル表示
 - 他クレートとの連携：
-  - `oso_bridge`：ブートローダとカーネルの橋渡し
-  - `oso_binary_parser`：DeviceTree(.dtb)等のバイナリ解析
+  - `oso_no_std_shared`：no_std環境での共有ライブラリ
   - `oso_proc_macro`：マクロによる自動コード生成
   - `oso_error`：エラー処理体系
 
@@ -69,10 +67,11 @@ cargo xt
 
 独自実装のUEFI対応ブートローダ。
 
-- `chibi_uefi` モジュールで、UEFIのRustラッパーを提供
 - ELF形式のカーネル読み込み機能
+- グラフィックス機能サポート（RGB/BGR/Bitmask形式）
 - 使用クレート：
-  - `oso_bridge`
+  - `oso_no_std_shared`
+  - `oso_proc_macro`
   - `oso_error`
 
 ### `xtask`
@@ -87,11 +86,11 @@ cargo xt
 
 | クレート名             | 説明                                                              |
 | ---------------------- | ----------------------------------------------------------------- |
-| `oso_binary_parser`    | ELFやDeviceTreeなどのバイナリ形式を解析するための抽象枠組みを提供 |
+| `oso_no_std_shared`    | no_std環境で共有される基本的なデータ構造とユーティリティを提供    |
 | `oso_proc_macro_logic` | 手続きマクロの実装内部ロジックとそのテスト                        |
 | `oso_proc_macro`       | カーネルの構造体やパーサ・テスト生成を支援するマクロ群            |
 | `oso_error`            | 共通エラー型とエラーハンドリングロジック                          |
-| `oso_bridge`           | ブートローダとカーネル間で共有されるデータ構造定義                |
+| `util_common_code`     | 開発ツール間で共有される汎用コード                                |
 
 ## build
 


### PR DESCRIPTION
## Summary

Updates the project structure documentation to reflect the current crate architecture and dependencies, removing outdated references and adding current functionality descriptions.

## Changes

### Japanese README updates:
- Remove `gui` module from oso_kernel module list
- Update crate dependencies:
  - Remove `oso_bridge` and `oso_binary_parser`
  - Add `oso_no_std_shared`
- Update oso_loader section:
  - Remove chibi_uefi reference
  - Add graphics support description
  - Update used crates list
- Update auxiliary crates table with current crates

### English README updates:
- Standardize section titles with backticks
- Update oso_kernel description and features
- Remove outdated module references (gui)
- Update crate integration lists to reflect current architecture
- Update oso_loader section with current functionality
- Improve xtask section description
- Update auxiliary crates table with proper English headers and current crates

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] All referenced crates exist in the current codebase
- [x] Descriptions match actual functionality
- [x] Table formatting is correct