### PR TITLE
feat(no-std-shared): add TreePart trait for atomic tree operations

### DIFF
--- a/oso_no_std_shared/src/data/tree.rs
+++ b/oso_no_std_shared/src/data/tree.rs
@@ -27,6 +27,16 @@ pub mod coord;
 pub mod walk_rslt;
 pub mod walker;
 
+//  TODO: -implement TreePart for Tree
+// - refactor codebase to use `TreePart` object as an atomic unit in `TreeWalk` and `TreeWindow`
+pub trait TreePart {
+	type N: NodeValue;
+	type C: Coordinate;
+
+	fn node(&self,) -> Self::N;
+	fn coord(&self,) -> Self::C;
+}
+
 /// A generic tree data structure with lifetime-managed references.
 ///
 /// This tree structure uses references to manage parent-child relationships


### PR DESCRIPTION
This PR introduces the TreePart trait to provide a foundation for atomic tree operations in the no_std shared library.

Changes:
- Add TreePart trait with node() and coord() methods  
- Support for generic NodeValue and Coordinate types
- Foundation for future refactoring of TreeWalk and TreeWindow

This trait enables atomic unit operations in tree data structures and prepares the codebase for improved tree manipulation patterns.