### PR TITLE
chore(no-std-shared): add refactoring TODO for error handling

### DIFF
--- a/oso_no_std_shared/src/data/tree/walk_rslt.rs
+++ b/oso_no_std_shared/src/data/tree/walk_rslt.rs
@@ -76,6 +76,8 @@ pub trait WalkTried {
 	fn from(tn: Self::T, coord: Self::C,) -> Self;
 }
 
+//  TODO: replace `WalkRslt` with `oso_error::Rslt`
+
 /// Concrete implementation of the `WalkTried` trait.
 ///
 /// This struct represents the result of a tree walk operation, containing


### PR DESCRIPTION
This PR adds documentation for future refactoring to improve error handling consistency.

Changes:
- Add TODO to replace WalkRslt with oso_error::Rslt
- Improves consistency with project error handling patterns
- Prepares for future error system unification

This change helps maintain technical debt visibility and guides future refactoring efforts toward a unified error handling approach.