### PR TITLE
chore(docs): update README files with latest date and correct crate name

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,7 +1,7 @@
 [日本語版](README.md)
 
 > This README contains AI-generated content that has been manually refined
-> Last updated: 250728
+> Last updated: 250731
 
 # `oso` — Experimental Pure Rust OS for aarch64
 
@@ -86,7 +86,7 @@ Developer auxiliary tool suite.
 | `oso_proc_macro_logic` | Internal logic implementation and testing for procedural macros               |
 | `oso_proc_macro`       | Macro suite supporting kernel struct, parser, and test generation             |
 | `oso_error`            | Common error types and error handling logic                                   |
-| `util_common_code`     | General-purpose code shared between development tools                         |
+| `oso_dev_util`         | General-purpose code shared between development tools                         |
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [english ver](README-en.md)
 
 > このREADMEはAIによって生成された文章に手直しを入れた物です
-> 最終更新日：250728
+> 最終更新日：250731
 
 # `oso` — 実験的aarch64向け純Rust製OS
 
@@ -88,7 +88,7 @@ cargo xt
 | `oso_proc_macro_logic` | 手続きマクロの実装内部ロジックとそのテスト                        |
 | `oso_proc_macro`       | カーネルの構造体やパーサ・テスト生成を支援するマクロ群            |
 | `oso_error`            | 共通エラー型とエラーハンドリングロジック                          |
-| `util_common_code`     | 開発ツール間で共有される汎用コード                                |
+| `oso_dev_util`         | 開発ツール間で共有される汎用コード                                |
 
 ## Build
 


### PR DESCRIPTION
## Summary

This PR updates the README documentation files with the latest information:

### Changes Made
- **Date Update**: Updated last modified date from 250728 to 250731 in both Japanese and English versions
- **Crate Name Correction**: Fixed incorrect crate name from 'util_common_code' to 'oso_dev_util' in the auxiliary crates table

### Purpose
- Maintains documentation accuracy and consistency
- Ensures both language versions are synchronized
- Corrects outdated crate naming in project structure documentation

### Files Modified
-  (Japanese version)
-  (English version)

This is a maintenance update to keep documentation current and accurate.