### PR TITLE
refactor(docs): fix documentation indentation

### DIFF
--- a/oso_error/src/lib.rs
+++ b/oso_error/src/lib.rs
@@ -112,8 +112,8 @@ pub mod parser;
 /// use oso_error::oso_err;
 ///
 /// fn might_fail() -> Rslt<i32, &'static str,> {
-/// 	// Some operation that might fail
-/// 	if true { Ok(42,) } else { Err(oso_err!("Operation failed"),) }
+///     // Some operation that might fail
+///     if true { Ok(42,) } else { Err(oso_err!("Operation failed"),) }
 /// }
 /// ```
 pub type Rslt<T = (), V = (),> = Result<T, OsoError<V,>,>;
@@ -154,8 +154,8 @@ pub type Rslt<T = (), V = (),> = Result<T, OsoError<V,>,>;
 ///
 /// #[derive(Debug, Default,)]
 /// struct NetworkError {
-/// 	status_code: u16,
-/// 	message:     String,
+///     status_code: u16,
+///     message:     String,
 /// }
 ///
 /// // Create an error with a custom description
@@ -191,10 +191,10 @@ where V: Debug
 /// use oso_error::oso_err;
 ///
 /// fn validate_input(input: i32,) -> Rslt<(), &'static str,> {
-/// 	if input < 0 {
-/// 		return Err(oso_err!("Negative input not allowed"),);
-/// 	}
-/// 	Ok((),)
+///     if input < 0 {
+///         return Err(oso_err!("Negative input not allowed"),);
+///     }
+///     Ok((),)
 /// }
 /// ```
 #[macro_export]
@@ -230,15 +230,15 @@ impl<V: Debug + Default,> OsoError<V,> {
 	///
 	/// #[derive(Debug, Default,)]
 	/// struct FileError {
-	/// 	path:      String,
-	/// 	operation: String,
+	///     path:      String,
+	///     operation: String,
 	/// }
 	///
 	/// fn read_file(path: &str,) -> Rslt<String, FileError,> {
-	/// 	// Simulate a file operation failure
-	/// 	let mut err = OsoError { from: module_path!(), desc: None, };
-	/// 	err.desc(FileError { path: path.into(), operation: "read".into(), },);
-	/// 	Err(err,)
+	///     // Simulate a file operation failure
+	///     let mut err = OsoError { from: module_path!(), desc: None, };
+	///     err.desc(FileError { path: path.into(), operation: "read".into(), },);
+	///     Err(err,)
 	/// }
 	/// ```
 	pub fn desc(&mut self, val: V,) -> &mut Self {

--- a/oso_loader/src/lib.rs
+++ b/oso_loader/src/lib.rs
@@ -88,7 +88,7 @@ fn panic(panic: &core::panic::PanicInfo,) -> ! {
 /// ```rust
 /// let result = some_operation();
 /// if let Err(e,) = result {
-/// 	on_error!(e, "during kernel loading");
+///     on_error!(e, "during kernel loading");
 /// }
 /// ```
 #[macro_export]

--- a/oso_loader/src/raw/types/util.rs
+++ b/oso_loader/src/raw/types/util.rs
@@ -5,9 +5,9 @@
 /// c_style_enum! {
 /// #[derive(Default)]
 /// pub enum UnixBool: i32 => #[allow(missing_docs)] {
-/// 	FALSE          = 0,
-/// 	TRUE           = 1,
-/// 	FILE_NOT_FOUND = -1,
+///     FALSE          = 0,
+///     TRUE           = 1,
+///     FILE_NOT_FOUND = -1,
 /// }}
 /// ```
 macro_rules! c_style_enum {

--- a/oso_no_std_shared/src/bridge/device_tree.rs
+++ b/oso_no_std_shared/src/bridge/device_tree.rs
@@ -19,8 +19,8 @@
 /// use oso_no_std_shared::bridge::device_tree::DeviceTreeAddress;
 ///
 /// fn process_device_tree(dtb_addr: DeviceTreeAddress,) {
-/// 	// Parse and process the device tree at the given address
-/// 	// ...
+///     // Parse and process the device tree at the given address
+///     // ...
 /// }
 ///
 /// // In kernel entry point:

--- a/oso_no_std_shared/src/bridge/graphic.rs
+++ b/oso_no_std_shared/src/bridge/graphic.rs
@@ -82,12 +82,12 @@ pub enum PixelFormatConf {
 ///
 /// // Create a new framebuffer configuration for a 1024x768 display with RGB format
 /// let framebuf = FrameBufConf::new(
-/// 	PixelFormatConf::Rgb,
-/// 	0x1000_0000 as *mut u8, // Base address
-/// 	1024 * 768 * 4,         // Size (bytes)
-/// 	1024,                   // Width (pixels)
-/// 	768,                    // Height (pixels)
-/// 	1024 * 4,               // Stride (bytes per row)
+///     PixelFormatConf::Rgb,
+///     0x1000_0000 as *mut u8, // Base address
+///     1024 * 768 * 4,         // Size (bytes)
+///     1024,                   // Width (pixels)
+///     768,                    // Height (pixels)
+///     1024 * 4,               // Stride (bytes per row)
 /// );
 ///
 /// // Access framebuffer properties
@@ -141,12 +141,12 @@ impl FrameBufConf {
 	///
 	/// // Create a new framebuffer configuration for a 1920x1080 display with RGB format
 	/// let framebuf = FrameBufConf::new(
-	/// 	PixelFormatConf::Rgb,
-	/// 	0x1000_0000 as *mut u8, // Base address
-	/// 	1920 * 1080 * 4,        // Size (bytes)
-	/// 	1920,                   // Width (pixels)
-	/// 	1080,                   // Height (pixels)
-	/// 	1920 * 4,               // Stride (bytes per row)
+	///     PixelFormatConf::Rgb,
+	///     0x1000_0000 as *mut u8, // Base address
+	///     1920 * 1080 * 4,        // Size (bytes)
+	///     1920,                   // Width (pixels)
+	///     1080,                   // Height (pixels)
+	///     1920 * 4,               // Stride (bytes per row)
 	/// );
 	/// ```
 	pub fn new(

--- a/oso_proc_macro_logic/src/test_program_headers_parse.rs
+++ b/oso_proc_macro_logic/src/test_program_headers_parse.rs
@@ -137,9 +137,9 @@ fn program_headers_fields(
 /// use anyhow::Result as Rslt;
 /// fn test_error_propagation() {
 ///     fn test_chain() -> Rslt<(),> {
-/// 	    let invalid_hex = "invalid_hex";
-/// 	    parse_str_hex_repr(invalid_hex,)?;
-/// 	    Ok((),)
+///         let invalid_hex = "invalid_hex";
+///         parse_str_hex_repr(invalid_hex,)?;
+///         Ok((),)
 ///     }
 ///
 ///     let result = test_chain();


### PR DESCRIPTION
## Summary

This PR standardizes documentation formatting across the oso codebase by replacing tabs with spaces in code examples.

## Changes Made

- **Error handling**: Fixed indentation in  documentation examples
- **Loader**: Standardized formatting in UEFI loader and utility macro docs
- **Bridge modules**: Improved readability of device tree and graphics examples
- **Proc macros**: Consistent formatting in test documentation

## Impact

- Improves code readability in documentation
- Ensures consistent formatting standards across all modules
- No functional changes to the codebase

## Testing

- All changes are documentation-only
- No impact on compilation or runtime behavior