### PR TITLE
chore(ci): migrate all workflows from Homebrew/apt to Nix

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -25,18 +25,12 @@ jobs:
         include:
           - os: ubuntu-24.04-arm
             platform: linux
-            qemu_install: |
-              sudo apt-get update
-              sudo apt-get install -y qemu-system-aarch64
             mount_test: |
               # Test Linux loop mount functionality
               echo "Testing Linux mount capabilities"
-              sudo losetup --version || echo "losetup not available"
+              nix develop --command bash -c "losetup --version || echo 'losetup not available'"
           - os: macos-14
             platform: macos
-            qemu_install: |
-              brew install qemu
-              brew install binutils
             mount_test: |
               # Test macOS hdiutil functionality
               echo "Testing macOS hdiutil capabilities"
@@ -46,8 +40,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install QEMU
-        run: ${{ matrix.qemu_install }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup development environment
+        run: |
+          nix develop --command bash -c "echo 'Development environment ready'"
+          # Verify tools are available
+          nix develop --command qemu-system-aarch64 --version
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -70,37 +72,36 @@ jobs:
       - name: Build all components
         run: |
           echo "Building on ${{ matrix.platform }}"
-          export PATH="/opt/homebrew/opt/binutils/bin:$PATH"
           # Build kernel
-          which readelf
+          nix develop --command readelf --version
           cd oso_kernel
-          cargo build --release
+          nix develop --command cargo build --release
           cd ..
           ls ./target
           
           # Build loader
           cd oso_loader
-          cargo build --release
+          nix develop --command cargo build --release
           cd ..
           
           # Build xtask
-          cargo build -p xtask --release
+          nix develop --command cargo build -p xtask --release
 
       - name: Test xtask platform detection
         run: |
           echo "Testing xtask platform detection on ${{ matrix.platform }}"
-          ./target/release/xtask --help || echo "xtask help completed"
+          nix develop --command ./target/release/xtask --help || echo "xtask help completed"
 
       - name: Quick boot test
         run: |
           echo "Running quick boot test on ${{ matrix.platform }}"
-          timeout 15s cargo run -p xtask || echo "Quick boot test completed (expected timeout)"
+          timeout 15s nix develop --command cargo run -p xtask || echo "Quick boot test completed (expected timeout)"
 
       - name: Full boot test (if requested)
         if: github.event.inputs.run_full_test == 'true'
         run: |
           echo "Running full boot test on ${{ matrix.platform }}"
-          timeout 60s cargo run -p xtask || echo "Full boot test completed"
+          timeout 60s nix develop --command cargo run -p xtask || echo "Full boot test completed"
 
       - name: Verify artifacts
         run: |
@@ -192,6 +193,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
 
@@ -199,23 +205,23 @@ jobs:
         run: |
           echo "Checking platform compatibility for ${{ matrix.platform }}"
           
-          # Check required tools
+          # Check required tools via Nix
           if [ "${{ matrix.platform }}" = "linux" ]; then
             echo "Checking Linux-specific tools:"
             which sudo || echo "sudo not found"
             which mount || echo "mount not found"
             which umount || echo "umount not found"
-            which losetup || echo "losetup not found"
+            nix develop --command bash -c "which losetup || echo 'losetup not found'"
           elif [ "${{ matrix.platform }}" = "macos" ]; then
             echo "Checking macOS-specific tools:"
             which hdiutil || echo "hdiutil not found"
           fi
           
-          # Check QEMU availability
-          which qemu-system-aarch64 || echo "qemu-system-aarch64 not found"
+          # Check QEMU availability via Nix
+          nix develop --command qemu-system-aarch64 --version
 
       - name: Test xtask platform detection
         run: |
-          cargo build -p xtask
+          nix develop --command cargo build -p xtask
           echo "Platform detection test:"
-          ./target/debug/xtask --help || echo "xtask platform detection test completed"
+          nix develop --command ./target/debug/xtask --help || echo "xtask platform detection test completed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install QEMU
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup development environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-aarch64
+          nix develop --command bash -c "echo 'Development environment ready'"
+          # Verify tools are available
+          nix develop --command qemu-system-aarch64 --version
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -130,12 +136,12 @@ jobs:
           key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build xtask
-        run: cargo build -p xtask
+        run: nix develop --command cargo build -p xtask
 
       - name: Test build process (aarch64 only)
         run: |
           # Test that the build process works without actually running QEMU
-          timeout 30s cargo run -p xtask -- --dry-run || true
+          timeout 30s nix develop --command cargo run -p xtask -- --dry-run || true
 
   security:
     name: Security Audit

--- a/.github/workflows/multi-platform-ci.yml
+++ b/.github/workflows/multi-platform-ci.yml
@@ -64,6 +64,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -90,7 +95,7 @@ jobs:
           cargo build --release
 
       - name: Build xtask
-        run: cargo build -p xtask --release
+        run: nix develop --command cargo build -p xtask --release
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
@@ -143,25 +148,23 @@ jobs:
         include:
           - os: ubuntu-24.04-arm
             platform: linux
-            qemu_package: qemu-system-aarch64
           - os: macos-14
             platform: macos
-            qemu_package: qemu
     runs-on: ${{ matrix.os }}
     needs: [build]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install QEMU (Linux)
-        if: matrix.platform == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.qemu_package }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install QEMU (macOS)
-        if: matrix.platform == 'macos'
+      - name: Setup development environment
         run: |
-          brew install ${{ matrix.qemu_package }}
+          nix develop --command bash -c "echo 'Development environment ready'"
+          # Verify tools are available
+          nix develop --command qemu-system-aarch64 --version
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -187,12 +190,12 @@ jobs:
       - name: Test build process
         run: |
           # Test that the build process works without actually running QEMU
-          timeout 30s cargo run -p xtask -- --dry-run || true
+          timeout 30s nix develop --command cargo run -p xtask -- --dry-run || true
 
       - name: Test QEMU boot (short timeout)
         run: |
           # Quick boot test with timeout to ensure the OS starts
-          timeout 10s cargo run -p xtask || echo "Boot test completed (expected timeout)"
+          timeout 10s nix develop --command cargo run -p xtask || echo "Boot test completed (expected timeout)"
 
   security:
     name: Security Audit
@@ -242,4 +245,4 @@ jobs:
         run: |
           echo "Running dependency check on ${{ matrix.platform }}"
           # Check that xtask properly detects the current platform
-          cargo run -p xtask -- --version || true
+          nix develop --command cargo run -p xtask -- --version || true

--- a/.github/workflows/multi-platform-release.yml
+++ b/.github/workflows/multi-platform-release.yml
@@ -24,14 +24,9 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: linux
             artifact_suffix: linux-aarch64
-            qemu_install: |
-              sudo apt-get update
-              sudo apt-get install -y qemu-system-aarch64
           - os: macos-14
             platform: macos
             artifact_suffix: macos-aarch64
-            qemu_install: |
-              brew install qemu
     runs-on: ${{ matrix.os }}
     
     outputs:
@@ -49,8 +44,16 @@ jobs:
           echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         fi
     
-    - name: Install QEMU
-      run: ${{ matrix.qemu_install }}
+    - name: Install Nix
+      uses: cachix/install-nix-action@v24
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup development environment
+      run: |
+        nix develop --command bash -c "echo 'Development environment ready'"
+        # Verify tools are available
+        nix develop --command qemu-system-aarch64 --version
     
     - name: Install Rust nightly
       uses: dtolnay/rust-toolchain@nightly
@@ -70,7 +73,7 @@ jobs:
     - name: Build kernel
       run: |
         cd oso_kernel
-        cargo build --target aarch64-unknown-none-elf.json --release
+        nix develop --command cargo build --target aarch64-unknown-none-elf.json --release
     
     - name: Copy kernel binary for loader
       run: |
@@ -81,15 +84,15 @@ jobs:
     - name: Build loader
       run: |
         cd oso_loader
-        cargo build --target aarch64-unknown-uefi --release
+        nix develop --command cargo build --target aarch64-unknown-uefi --release
     
     - name: Build xtask
-      run: cargo build -p xtask --release
+      run: nix develop --command cargo build -p xtask --release
     
     - name: Test build on platform
       run: |
         echo "Testing build on ${{ matrix.platform }}"
-        timeout 10s cargo run -p xtask -- --dry-run || echo "Build test completed"
+        timeout 10s nix develop --command cargo run -p xtask -- --dry-run || echo "Build test completed"
     
     - name: Create platform-specific release artifacts
       run: |
@@ -104,7 +107,7 @@ jobs:
         echo "Platform: ${{ matrix.platform }}" > release-artifacts/PLATFORM_INFO.txt
         echo "Built on: $(date)" >> release-artifacts/PLATFORM_INFO.txt
         echo "Rust version: $(rustc --version)" >> release-artifacts/PLATFORM_INFO.txt
-        echo "QEMU version: $(qemu-system-aarch64 --version | head -n1)" >> release-artifacts/PLATFORM_INFO.txt
+        echo "QEMU version: $(nix develop --command qemu-system-aarch64 --version | head -n1)" >> release-artifacts/PLATFORM_INFO.txt
         
         # Create checksums
         cd release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,27 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
+    - name: Install Nix
+      uses: cachix/install-nix-action@v24
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup development environment
+      run: |
+        nix develop --command bash -c "echo 'Development environment ready'"
+        # Verify tools are available
+        nix develop --command qemu-system-aarch64 --version
+    
     - name: Install Rust nightly
       uses: dtolnay/rust-toolchain@nightly
       with:
         components: rust-src
         targets: aarch64-unknown-uefi
     
-    - name: Install QEMU
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y qemu-system-aarch64
-    
     - name: Build kernel
       run: |
         cd oso_kernel
-        cargo build --target aarch64-unknown-none-elf.json --release
+        nix develop --command cargo build --target aarch64-unknown-none-elf.json --release
     
     - name: Copy kernel binary for loader
       run: |
@@ -40,10 +46,10 @@ jobs:
     - name: Build loader
       run: |
         cd oso_loader
-        cargo build --target aarch64-unknown-uefi --release
+        nix develop --command cargo build --target aarch64-unknown-uefi --release
     
     - name: Build xtask
-      run: cargo build -p xtask --release
+      run: nix develop --command cargo build -p xtask --release
     
     - name: Create release artifacts
       run: |


### PR DESCRIPTION
## Summary

This PR migrates all GitHub Actions workflows from platform-specific package managers (Homebrew on macOS, apt on Linux) to a unified Nix-based approach.

## Changes

### Workflows Updated
- **ci.yml**: Replace apt-get QEMU installation with Nix
- **build-and-run.yml**: Remove Homebrew/apt dependencies, use Nix for all platforms
- **multi-platform-ci.yml**: Unify QEMU installation across platforms
- **multi-platform-release.yml**: Migrate all build commands to Nix environment
- **release.yml**: Replace apt-get with Nix setup

### Key Improvements
- **Unified approach**: Same dependency management across Linux and macOS
- **Reproducible builds**: Exact same tool versions on all platforms
- **Simplified maintenance**: Single source of truth for dependencies in flake.nix
- **Removed complexity**: No more platform-specific installation logic
- **PATH cleanup**: Removed hardcoded Homebrew PATH manipulation

## Dependencies

This PR depends on the enhanced flake.nix configuration from PR #61.

## Benefits

- **Consistency**: Identical build environments across all CI platforms
- **Reliability**: Reproducible builds with pinned tool versions
- **Maintainability**: Centralized dependency management
- **Developer alignment**: CI environment matches local development setup