### PR TITLE
chore(ci): add Nix installation to multi-platform CI workflow

### DIFF
--- a/.github/workflows/multi-platform-ci.yml
+++ b/.github/workflows/multi-platform-ci.yml
@@ -30,6 +30,11 @@ jobs:
           components: rustfmt, clippy, rust-src
           targets: aarch64-unknown-uefi
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary

This PR adds Nix installation support to the multi-platform CI workflow to enhance build environment capabilities.

## Changes
- Added Nix installation step using `cachix/install-nix-action@v24`
- Configured with GitHub token for proper authentication
- Enables reproducible builds and better dependency management

## Benefits
- Improved build reproducibility
- Enhanced development environment consistency
- Better support for complex build dependencies

## Testing
- CI workflow will now include Nix installation step
- No breaking changes to existing build process