### PR TITLE
feat(ci): add kernel build step to test workflow

### DIFF
--- a/.github/workflows/multi-platform-ci.yml
+++ b/.github/workflows/multi-platform-ci.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Run tests for std crates
         run: |
           # Test crates that can run in std environment
+          (cd oso_kernel && nix develop --command cargo b)
           (cd oso_proc_macro_logic && nix develop --command cargo test)
           (cd oso_error && nix develop --command cargo test)
           (cd xtask && nix develop --command cargo test)


### PR DESCRIPTION
## Summary

Adds kernel build verification to the CI test workflow to ensure the core `oso_kernel` component compiles successfully.

## Changes

- Add `oso_kernel` build step to multi-platform CI test job
- Uses `nix develop --command cargo b` for consistent build environment
- Placed before other crate tests for logical flow

## Benefits

- Improves CI coverage for the core kernel component
- Catches kernel compilation issues early in the development cycle
- Ensures kernel builds successfully across all supported platforms
- Maintains consistency with existing test patterns

## Testing

The kernel build step will run in the same nix development environment as other components, ensuring compatibility and consistency.