### PR TITLE
chore(proc_macro): remove extra blank line in helper.rs

### DIFF
--- a/oso_proc_macro/src/helper.rs
+++ b/oso_proc_macro/src/helper.rs
@@ -13,7 +13,6 @@ use proc_macro::Diagnostic;
 use proc_macro::Level;
 use proc_macro2::Span;
 
-
 pub trait ErrorDiagnose {
 	type T;
 	fn unwrap_or_emit(self,) -> Self::T;


### PR DESCRIPTION
## Summary

Minor code cleanup to remove unnecessary whitespace in the proc macro helper module.

## Changes

- **Removed extra blank line** between imports and trait definition in helper.rs
- **Improved code formatting consistency** across the module

## Benefits

- Cleaner, more consistent code formatting
- Reduced visual clutter in the source file
- Better adherence to project style guidelines

This is a minor maintenance change with no functional impact.