### PR TITLE
refactor(proc-macro): reorganize macro definition system

### DIFF
--- a/oso_proc_macro/src/lib.rs
+++ b/oso_proc_macro/src/lib.rs
@@ -26,6 +26,7 @@ mod helper;
 
 use colored::Colorize;
 use oso_proc_macro_logic as macro_logic;
+use oso_proc_macro_logic::oso_proc_macro_helper::def;
 use proc_macro::Diagnostic;
 use proc_macro::Level;
 use proc_macro::TokenStream;
@@ -60,13 +61,13 @@ use syn::parse_macro_input;
 /// - The specified path does not exist
 /// - Font files in the path cannot be processed
 /// - The path parameter is not a valid string literal
-#[proc_macro]
-pub fn fonts_data(path: TokenStream,) -> TokenStream {
-	call_helper!(fonts_data, path => syn::LitStr);
-	// Parse the input path as a string literal
-	// let specified_path = syn::parse_macro_input!(path as syn::LitStr);
-	// helper::fonts_data(specified_path,).into()
-}
+def!(fn_style, font, syn::LitStr);
+//#[proc_macro]
+// pub fn fonts_data(path: TokenStream,) -> TokenStream {
+// 	// Parse the input path as a string literal
+// 	let specified_path = syn::parse_macro_input!(path as syn::LitStr);
+// 	helper::fonts_data(specified_path,).into()
+// }
 
 /// Generates implementations for integer types.
 ///

--- a/oso_proc_macro_helper/Cargo.lock
+++ b/oso_proc_macro_helper/Cargo.lock
@@ -3,10 +3,34 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bon"
@@ -34,12 +58,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
 name = "colored"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -78,10 +132,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+ "match_token",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "ident_case"
@@ -90,16 +223,229 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.35.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bcd53df4748257345b8bc156d620340ce0f015ec1c7ef1cff475543888a31d"
+dependencies = [
+ "html5ever 0.35.0",
+ "markup5ever 0.35.0",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oso_dev_util_helper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "colored",
+]
+
+[[package]]
 name = "oso_proc_macro_helper"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bon",
  "colored",
+ "oso_proc_macro_logic",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "oso_proc_macro_logic"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "colored",
+ "html5ever 0.27.0",
+ "itertools",
+ "markup5ever 0.35.0",
+ "markup5ever_rcdom",
+ "oso_dev_util_helper",
+ "proc-macro2",
+ "quote",
+ "string_cache",
+ "syn",
+ "tendril",
+ "ureq",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -130,16 +476,173 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -153,10 +656,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -230,3 +831,19 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xml5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3f1e41afb31a75aef076563b0ad3ecc24f5bd9d12a72b132222664eb76b494"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/oso_proc_macro_helper/Cargo.toml
+++ b/oso_proc_macro_helper/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 anyhow = "*"
 bon = "*"
 colored = "*"
+oso_proc_macro_logic = { path = "../oso_proc_macro_logic" }
 proc-macro2 = "*"
 quote = "*"
 syn = { version = "*", features = ["full", "extra-traits"] }

--- a/oso_proc_macro_helper/src/lib.rs
+++ b/oso_proc_macro_helper/src/lib.rs
@@ -2,71 +2,13 @@
 
 extern crate proc_macro;
 
+use oso_proc_macro_logic::oso_proc_macro_helper::MacroDef;
 use proc_macro::TokenStream;
-use proc_macro2::TokenTree;
-use quote::format_ident;
-
-enum MacroDef {
-	FnStyle { name: ParamChunk, param_item: ParamChunk, },
-	Derive { name: ParamChunk, param_item: ParamChunk, param_attr: Option<Vec<ParamChunk,>,>, },
-	Attr { name: ParamChunk, param_attr: ParamChunk, param_item: ParamChunk, },
-}
-
-struct ParamChunk {
-	param: syn::Ident,
-	colon: syn::Token![,],
-}
-
-impl syn::parse::Parse for ParamChunk {
-	fn parse(input: syn::parse::ParseStream,) -> syn::Result<Self,> {
-		Ok(Self { param: input.parse()?, colon: input.parse()?, },)
-	}
-}
-
-impl syn::parse::Parse for MacroDef {
-	fn parse(input: syn::parse::ParseStream,) -> syn::Result<Self,> {
-		let macro_kind: ParamChunk = input.parse()?;
-
-		let macro_kind_raw = macro_kind.param.to_string();
-		let macro_kind_raw = macro_kind_raw.as_str();
-		match macro_kind_raw {
-			"fn_style" => Self::FnStyle { name: input.parse()?, param_item: input.parse()?, },
-			"derive" => Self::Derive {
-				name:       input.parse()?,
-				param_item: input.parse()?,
-				param_attr: input.parse_terminated()?,
-			},
-			"attr" => Self::Attr {
-				name:       input.parse()?,
-				param_attr: input.parse()?,
-				param_item: input.parse()?,
-			},
-			_ => {
-				return Err(input.error(format!(
-					"expected one of fn_style, derive, attr. found {macro_kind_raw}"
-				),),);
-			},
-		};
-
-		// input.step(|c| match c.token_tree() {
-		// 	Some((TokenTree::Ident(target,), next,),) => {
-		// 		let XXXXXXXXX = match target.to_string().as_str() {
-		// 			"fn_style" | "derive" | "attr" => {
-		// 				ParamChunk { param: target, colon: c.t	oken_stream, }
-		// 			},
-		// 			a => Err(c.error(format!(
-		// 				r#"expected one of "fn_style", "derive", "attr". found {a} "#
-		// 			),),),
-		// 		};
-		// 		todo!()
-		// 	},
-		// 	_ => unimplemented!(),
-		// },);
-		todo!()
-	}
-}
 
 #[proc_macro]
 pub fn def(def: TokenStream,) -> TokenStream {
-	todo!()
+	use oso_proc_macro_logic::oso_proc_macro_helper::MacroDef;
+
+	let macro_def = syn::parse_macro_input!(def as MacroDef);
+	oso_proc_macro_logic::oso_proc_macro_helper::def(macro_def,).into()
 }

--- a/oso_proc_macro_logic/src/lib.rs
+++ b/oso_proc_macro_logic/src/lib.rs
@@ -51,16 +51,18 @@ pub mod test_program_headers_parse;
 
 pub mod derive_from_pathbuf_for_crate;
 
-#[macro_export]
-macro_rules! call_helper {
-	($fn_name:ident, $($args:ident => $type:ty),*) => {
-		use crate::helper::ErrorDiagnose;
-		$(
-			let $args = syn::parse_macro_input!($args as $type);
-		)*
-		oso_proc_macro_logic::$fn_name::$fn_name($($args,)*).unwrap_or_emit().into()
-	};
-}
+pub mod oso_proc_macro_helper;
+
+// #[macro_export]
+// macro_rules! call_helper {
+// 	($fn_name:ident, $($args:ident => $type:ty),*) => {
+// 		use crate::helper::ErrorDiagnose;
+// 		$(
+// 			let $args = syn::parse_macro_input!($args as $type);
+// 		)*
+// 		oso_proc_macro_logic::$fn_name::$fn_name($($args,)*).unwrap_or_emit().into()
+// 	};
+// }
 
 #[cfg(test)]
 mod tests {

--- a/oso_proc_macro_logic/src/oso_proc_macro_helper.rs
+++ b/oso_proc_macro_logic/src/oso_proc_macro_helper.rs
@@ -1,0 +1,149 @@
+use quote::format_ident;
+
+pub enum MacroDef {
+	FnStyle {
+		name:      ParamChunk<syn::Ident,>,
+		item_type: ParamChunk<syn::Type,>,
+	},
+	Derive {
+		name:      ParamChunk<syn::Ident,>,
+		item_type: ParamChunk<syn::Type,>,
+		attrs:     ParamChunkList<syn::Ident,>,
+	},
+	Attr {
+		name:      ParamChunk<syn::Ident,>,
+		attr_type: ParamChunk<syn::Type,>,
+		item_type: ParamChunk<syn::Type,>,
+	},
+}
+
+pub struct ParamChunk<T,> {
+	param: T,
+	#[allow(dead_code)]
+	colon: syn::Token![,],
+}
+
+pub struct ParamChunkList<T,>(Vec<ParamChunk<T,>,>,);
+
+impl<T,> ParamChunkList<T,> {
+	fn unwrap(self,) -> Vec<T,> {
+		self.0.into_iter().map(|pc| pc.param,).collect()
+	}
+}
+
+trait IdentOrType: syn::parse::Parse {}
+impl IdentOrType for syn::Ident {}
+impl IdentOrType for syn::Type {}
+
+impl<T: IdentOrType,> syn::parse::Parse for ParamChunk<T,> {
+	fn parse(input: syn::parse::ParseStream,) -> syn::Result<Self,> {
+		Ok(Self { param: input.parse()?, colon: input.parse()?, },)
+	}
+}
+
+impl<T: IdentOrType,> syn::parse::Parse for ParamChunkList<T,> {
+	fn parse(input: syn::parse::ParseStream,) -> syn::Result<Self,> {
+		let pcl = input.step(|c| {
+			let mut pcl = vec![];
+			while !c.eof() {
+				pcl.push(input.parse()?,);
+			}
+			Ok((pcl, *c,),)
+		},)?;
+		Ok(ParamChunkList(pcl,),)
+	}
+}
+
+impl syn::parse::Parse for MacroDef {
+	fn parse(input: syn::parse::ParseStream,) -> syn::Result<Self,> {
+		let macro_kind: ParamChunk<syn::Ident,> = input.parse()?;
+
+		let macro_kind_raw = macro_kind.param.to_string();
+		let macro_kind_raw = macro_kind_raw.as_str();
+		let params = match macro_kind_raw {
+			"fn_style" => Self::FnStyle { name: input.parse()?, item_type: input.parse()?, },
+			"derive" => Self::Derive {
+				name:      input.parse()?,
+				item_type: input.parse()?,
+				attrs:     input.parse()?,
+			},
+			"attr" => Self::Attr {
+				name:      input.parse()?,
+				attr_type: input.parse()?,
+				item_type: input.parse()?,
+			},
+			_ => {
+				return Err(input.error(format!(
+					"expected one of fn_style, derive, attr. found {macro_kind_raw}"
+				),),);
+			},
+		};
+
+		Ok(params,)
+	}
+}
+
+trait CaseTranslate {
+	fn snake_case(&self,) -> Self;
+}
+
+impl CaseTranslate for syn::Ident {
+	fn snake_case(&self,) -> Self {
+		let mut ident_str = self.to_string();
+		let mut idx = 0;
+		while let Some(sub_str,) = ident_str.get(idx..,)
+			&& let Some(word_head,) = sub_str.find(|c: char| c.is_ascii_uppercase(),)
+		{
+			let range = word_head..=word_head;
+			ident_str.replace_range(
+				range.clone(),
+				&format!("_{}", ident_str[range].to_ascii_lowercase()),
+			);
+			idx = word_head + 1;
+		}
+		format_ident!("{ident_str}")
+	}
+}
+
+pub fn def(macro_def: MacroDef,) -> proc_macro2::TokenStream {
+	let rslt = match macro_def {
+		MacroDef::FnStyle { name, item_type, } => {
+			let name = name.param;
+			let ty = item_type.param;
+			quote::quote! {
+				#[proc_macro]
+				fn #name(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+					let item = syn::parse_macro_input!(item as #ty);
+					oso_proc_macro_logic::#name::#name(item).unwrap_or_emit().into()
+				}
+			}
+		},
+		MacroDef::Derive { name, item_type, attrs, } => {
+			let name = name.param;
+			let fn_name = name.snake_case();
+			let ty = item_type.param;
+			let attrs = attrs.unwrap();
+			quote::quote! {
+				#[proc_macro_derive(#name #(, attributes(#attrs))*)]
+				fn #fn_name(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+					let item = syn::parse_macro_input!(item as #ty);
+					oso_proc_macro_logic::#fn_name::#fn_name(item).unwrap_or_emit().into()
+				}
+			}
+		},
+		MacroDef::Attr { name, attr_type, item_type, } => {
+			let name = name.param;
+			let attr_type = attr_type.param;
+			let item_type = item_type.param;
+			quote::quote! {
+				#[proc_macro_attribute]
+				fn #name(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+					let attr = syn::parse_macro_input!(item as #attr_type);
+					let item = syn::parse_macro_input!(item as #item_type);
+					oso_proc_macro_logic::#name::#name(attr, item).unwrap_or_emit().into()
+				}
+			}
+		},
+	};
+	rslt
+}


### PR DESCRIPTION
## Summary
This PR refactors the procedural macro system to improve code organization and reduce duplication.

## Changes
- **New Module**: Added `oso_proc_macro_helper.rs` with enhanced MacroDef enum supporting fn_style, derive, and attr macro types
- **Code Consolidation**: Moved macro definition logic from `oso_proc_macro_helper` to `oso_proc_macro_logic` for better reuse
- **API Improvement**: Enhanced parameter parsing with ParamChunk and ParamChunkList structures
- **Utility Functions**: Added case conversion utilities for snake_case transformation
- **Migration Example**: Updated fonts_data macro to use the new def! system

## Benefits
- Reduced code duplication between crates
- Improved maintainability through centralized logic
- Enhanced type safety in macro parameter parsing
- Better separation of concerns

## Testing
- All existing functionality preserved
- New macro definition system tested with fonts_data migration