### PR TITLE
refactor(proc_macro): replace individual macro definitions with generic def! macro system

### DIFF
--- a/oso_proc_macro/src/lib.rs
+++ b/oso_proc_macro/src/lib.rs
@@ -32,36 +32,69 @@ use proc_macro::Level;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
-/// Generates embedded font data from font files at compile time.
-///
-/// This procedural macro takes a relative path to the project root and processes
-/// font files to generate embedded data structures that can be used at runtime.
-/// The macro converts font data into bitfield representations for efficient storage.
-///
-/// # Parameters
-///
-/// * `path` - A string literal containing the relative path from the project root to the directory
-///   containing font data files
-///
-/// # Returns
-///
-/// Returns a token stream representing an array slice of processed font data.
-/// The generated code will be in the form `&[font_data_1, font_data_2, ...]`.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// // Generate font data from files in the "assets/fonts" directory
-/// let fonts = fonts_data!("assets/fonts");
-/// ```
-///
-/// # Panics
-///
-/// This macro will cause a compile-time error if:
-/// - The specified path does not exist
-/// - Font files in the path cannot be processed
-/// - The path parameter is not a valid string literal
-def!(fn_style, font, syn::LitStr);
+macro_rules! def {
+	(fn_style: $name:ident => $ty:ty, $doc:literal)=>{
+		#[proc_macro]
+		#[doc = $doc]
+		pub fn $name(item: proc_macro::TokenStream,) -> proc_macro::TokenStream {
+			def!{ macro_impl: $name, item => $ty }
+		}
+	};
+	(derive: name: $derive:ident, $name:ident => $ty:ty, $(attributes: $($attributes:ident,)+)?) => {
+		#[proc_macro_derive($derive $($(, attributes($attributes))+)?)]
+		#[doc = $doc]
+		pub fn $name(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+			def!(macro_impl: $name, item => $ty);
+
+		}
+	};
+	(attr: $name:ident => $ty:ty,)=>{
+		#[proc_macro_attribute]
+		#[doc = $doc]
+		pub fn $name(item: proc_macro::TokenStream,) -> proc_macro::TokenStream {
+			def!(macro_impl: $name, item, attr => $ty,);
+		}
+	};
+	(macro_impl: $name:ident, $param1:ident $(, $param2:ident)? => $ty:ty)=>{
+		let $param1 = syn::parse_macro_input!($param1 as $ty);
+		$(
+			let $param2 = syn::parse_macro_input!($param2 as proc_macro2::TokenStream);
+		)?
+
+		oso_proc_macro_logic::$name::$name($param1, $($param2,)?).unwrap_or_emit().into()
+	};
+}
+
+def!(fn_style: font => syn::LitStr,
+r#"Generates embedded font data from font files at compile time.
+
+	This procedural macro takes a relative path to the project root and processes
+	font files to generate embedded data structures that can be used at runtime.
+	The macro converts font data into bitfield representations for efficient storage.
+
+	# Parameters
+
+	* `path` - A string literal containing the relative path from the project root to the directory
+	  containing font data files
+
+	# Returns
+
+	Returns a token stream representing an array slice of processed font data.
+	The generated code will be in the form `&[font_data_1, font_data_2, ...]`.
+
+	# Examples
+
+	```rust,ignore
+	// Generate font data from files in the "assets/fonts" directory
+	let fonts = fonts_data!("assets/fonts");
+	```
+
+	# Panics
+
+	This macro will cause a compile-time error if:
+	- The specified path does not exist
+	- Font files in the path cannot be processed
+	- The path parameter is not a valid string literal"#);
 //#[proc_macro]
 // pub fn fonts_data(path: TokenStream,) -> TokenStream {
 // 	// Parse the input path as a string literal


### PR DESCRIPTION
## Summary

This PR introduces a unified macro definition system that replaces individual procedural macro implementations with a generic `def!` macro approach.

## Changes

- **Unified Macro System**: Introduced a `def!` macro that handles different macro types (fn_style, derive, attr)
- **Code Reduction**: Replaced hardcoded `fonts_data` macro definition with the generic approach
- **Improved Maintainability**: Reduced boilerplate code and improved consistency across macro definitions
- **Enhanced Documentation**: Better formatted documentation with proper indentation
- **Streamlined Implementation**: Consistent pattern for all macro implementations

## Benefits

- Easier to add new procedural macros
- Reduced code duplication
- More maintainable codebase
- Consistent macro implementation patterns

## Testing

The refactored code maintains the same public API and functionality as before.