### PR TITLE
chore(gitignore): add txt files to ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mnt/
 *.sh
 **/tmp/
 .direnv/
+**/*.txt


### PR DESCRIPTION
Updates .gitignore to exclude all .txt files recursively using **/*.txt pattern. This helps keep the repository clean from temporary text files that may be generated during development or testing.