### PR TITLE
feat(dev-util): add CLI module structure

### DIFF
--- a/oso_dev_util/src/cli.rs
+++ b/oso_dev_util/src/cli.rs
@@ -1,0 +1,9 @@
+use crate::decl_manage::crate_::OsoCrate;
+
+//  TODO: refactor to use clap
+pub struct XtaskInfo {
+	opts:   Opts,
+	ws:     OsoCrate,
+	assets: Assets,
+	host:   Host,
+}

--- a/oso_dev_util/src/lib.rs
+++ b/oso_dev_util/src/lib.rs
@@ -68,6 +68,7 @@
 
 use anyhow::Result as Rslt;
 
+pub mod cli;
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// flowchart TD


### PR DESCRIPTION
## Summary
This PR introduces a new CLI module to the oso_dev_util crate, laying the foundation for command-line interface functionality.

## Changes
- Add new `cli.rs` module with `XtaskInfo` struct
- Export CLI module in `lib.rs`
- Prepare structure for future clap integration
- Support xtask command-line interface development

## Purpose
This change establishes the basic structure needed for CLI operations in the development utilities, supporting the oso project's build and development workflow automation.