### PR TITLE
refactor(dev-util): rename land method to land_on

### DIFF
--- a/oso_dev_util/src/decl_manage/crate_.rs
+++ b/oso_dev_util/src/decl_manage/crate_.rs
@@ -158,7 +158,7 @@ impl CrateCalled for OsoCrate {
 impl Workspace for OsoCrate {}
 impl WorkspaceAction for OsoCrate {}
 impl WorkspaceSurvey for OsoCrate {
-	fn land(&mut self, on: impl CrateCalled,) -> impl Crate {
+	fn land_on(&mut self, on: impl CrateCalled,) -> impl Crate {
 		todo!()
 	}
 }

--- a/oso_dev_util/src/decl_manage/workspace.rs
+++ b/oso_dev_util/src/decl_manage/workspace.rs
@@ -78,14 +78,14 @@ pub trait WorkspaceAction: WorkspaceInfo + CrateAction {
 		let current = self.whoami();
 		//  this operation is safe due to `&self` is valid
 		let self_mut = unsafe { (self as *const Self).cast_mut().as_mut().unwrap() };
-		self_mut.land(at,).cargo_xxx_with(cmd, opt,)?;
-		self_mut.land(current,);
+		self_mut.land_on(at,).cargo_xxx_with(cmd, opt,)?;
+		self_mut.land_on(current,);
 		Ok((),)
 	}
 }
 
 pub trait WorkspaceSurvey: WorkspaceInfo + CrateSurvey {
-	fn land(&mut self, on: impl CrateCalled,) -> impl Crate;
+	fn land_on(&mut self, on: impl CrateCalled,) -> impl Crate;
 }
 
 /// Trait for managing OSO workspace operations


### PR DESCRIPTION
## Summary
This PR improves the workspace API by renaming the `land` method to `land_on` for better semantic clarity.

## Changes
- Rename `WorkspaceSurvey::land` to `land_on`
- Update all method calls in `WorkspaceAction` trait
- Improve method naming consistency across workspace API

## Purpose
The new name `land_on` better expresses the intent of navigating to a specific workspace location, making the API more intuitive and self-documenting.