### PR TITLE
chore(dev_util): reorder imports for better organization

### DIFF
--- a/oso_dev_util/src/cli.rs
+++ b/oso_dev_util/src/cli.rs
@@ -1,6 +1,5 @@
-use oso_proc_macro::features;
-
 use crate::decl_manage::crate_::OsoCrate;
+use oso_proc_macro::features;
 use std::path::PathBuf;
 
 //  TODO: refactor to use clap


### PR DESCRIPTION
This PR reorders imports in the dev_util CLI module to follow Rust conventions.

**Changes:**
- Move oso_proc_macro import after local imports
- Improve code readability and organization

**Why:**
- Follows standard Rust import ordering conventions
- Makes the code more maintainable and consistent