### PR TITLE
refactor(proc_macro_logic): clean up features processing logic

### DIFF
--- a/oso_proc_macro_logic/src/features.rs
+++ b/oso_proc_macro_logic/src/features.rs
@@ -7,16 +7,21 @@ use quote::ToTokens;
 use quote::format_ident;
 
 pub fn features(_attr: proc_macro2::TokenStream, mut item: syn::ItemEnum,) -> RsltP {
-	panic!("{item:#?}");
 	let mut hs = std::collections::HashSet::new();
-	all_crates()?.iter().filter_map(read_toml,).try_for_each(|toml| -> Rslt<(),> {
-		if let Some(toml::Value::Table(t,),) = toml?.get("features",) {
-			t.into_iter().for_each(|(feature, _,)| {
-				hs.insert(feature.clone(),);
-			},);
-		}
-		Ok((),)
-	},)?;
+	all_crates()?
+		.iter()
+		.filter_map(|e| {
+			let e = e.join(oso_dev_util_helper::fs::CARGO_MANIFEST,);
+			read_toml(e,)
+		},)
+		.try_for_each(|toml| -> Rslt<(),> {
+			if let Some(toml::Value::Table(t,),) = toml?.get("features",) {
+				t.into_iter().for_each(|(feature, _,)| {
+					hs.insert(feature.clone(),);
+				},);
+			}
+			Ok((),)
+		},)?;
 
 	hs.iter().for_each(|variant| {
 		let variant: String = variant.to_camel();


### PR DESCRIPTION
This PR refactors the features processing logic in the procedural macro system for better maintainability and readability.

**Changes:**
- Remove debug panic statement that was accidentally left in code
- Refactor iterator chain for improved readability
- Use proper path joining with CARGO_MANIFEST constant
- Improve overall code structure

**Why:**
- Removes debugging code that shouldn't be in production
- Makes the code more maintainable and easier to understand
- Follows better Rust practices for path handling