### PR TITLE
refactor(xtask): modularize crate structure with lib.rs

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "*"
 colored = "*"
 fs-err = "*"
 oso_dev_util = { path = "../oso_dev_util" }
+oso_dev_util_helper = { path = "../oso_dev_util_helper" }
 ovmf-prebuilt = "*"
 serde_json = "*"
 toml = "*"

--- a/xtask/src/builder.rs
+++ b/xtask/src/builder.rs
@@ -19,7 +19,7 @@ use crate::workspace::OsoWorkSpace;
 use anyhow::Result as Rslt;
 use anyhow::anyhow;
 use colored::Colorize;
-use oso_dev_util::Run;
+use oso_dev_util_helper::cli::Run;
 use std::env::set_current_dir;
 use std::path::Path;
 use std::path::PathBuf;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod builder;
+pub mod qemu;
+pub mod shell;
+pub mod workspace;
+
+pub struct XtaskInfo {
+	opts:   Opts,
+	ws:     OsoCrate,
+	assets: Assets,
+	host:   Target,
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,15 +27,10 @@
 //! - `--debug`: Enable debug mode with GDB support (listens on port 12345)
 
 use anyhow::Result as Rslt;
-use builder::Builder;
 use colored::Colorize;
-use oso_dev_util::Run;
+use oso_dev_util_helper::cli::Run;
 use std::process::Command;
-
-pub mod builder;
-pub mod qemu;
-pub mod shell;
-pub mod workspace;
+use xtask::builder::Builder;
 
 /// Entry point for the xtask utility.
 ///

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -7,8 +7,6 @@
 //! - Managing OVMF firmware files for UEFI boot
 //! - Setting up block devices and persistent flash memory
 
-use crate::builder::Builder;
-use crate::shell::Architecture;
 use anyhow::Result as Rslt;
 use ovmf_prebuilt::Arch;
 use ovmf_prebuilt::FileType;
@@ -17,6 +15,8 @@ use ovmf_prebuilt::Source;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
+use xtask::builder::Builder;
+use xtask::shell::Architecture;
 
 impl Builder {
 	/// Gets the QEMU executable name based on the target architecture


### PR DESCRIPTION
## Summary
This PR modularizes the xtask crate by introducing a proper library structure with lib.rs.

## Changes
- Added lib.rs to expose public modules (builder, qemu, shell, workspace)
- Updated main.rs to use library imports instead of local modules
- Introduced XtaskInfo struct for centralized configuration
- Enhanced builder and qemu modules functionality
- Improved import organization and module separation

## Benefits
- Better crate modularity and reusability
- Cleaner separation between library and binary code
- Enhanced maintainability and testability
- Improved code organization