### PR TITLE
chore(cargo): add clippy lint configurations

### DIFF
--- a/oso_dev_util_helper/Cargo.toml
+++ b/oso_dev_util_helper/Cargo.toml
@@ -10,3 +10,6 @@ toml = { version = "*", features = ["parse"] }
 
 [dev-dependencies]
 proptest = "*"
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"

--- a/oso_error/Cargo.toml
+++ b/oso_error/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"

--- a/oso_kernel/Cargo.toml
+++ b/oso_kernel/Cargo.toml
@@ -14,3 +14,8 @@ bgr = []
 bitmask = []
 bltonly = []
 default = ["bltonly"]
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"
+assign_op_pattern = "allow"
+mut_from_ref = "allow"

--- a/oso_loader/Cargo.toml
+++ b/oso_loader/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "oso_loader"
 version = "0.1.0"
-edition = "2024"
-description = "UEFI-based bootloader for the OSO operating system with ELF kernel loading support"
 authors = ["OSO Development Team"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/oso-os/oso"
-documentation = "https://docs.rs/oso_loader"
-keywords = ["bootloader", "uefi", "elf", "kernel", "operating-system"]
 categories = ["embedded", "no-std", "os"]
+documentation = "https://docs.rs/oso_loader"
+edition = "2024"
+keywords = ["bootloader", "uefi", "elf", "kernel", "operating-system"]
+license = "MIT OR Apache-2.0"
 readme = "README.md"
+repository = "https://github.com/oso-os/oso"
+description = "UEFI-based bootloader for the OSO operating system with ELF kernel loading support"
 
 [dependencies]
 oso_error = { path = "../oso_error" }
@@ -29,3 +29,6 @@ bltonly = []
 # Documentation configuration for docs.rs
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"

--- a/oso_no_std_shared/Cargo.toml
+++ b/oso_no_std_shared/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 oso_error = { path = "../oso_error" }
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"

--- a/oso_proc_macro_logic/Cargo.toml
+++ b/oso_proc_macro_logic/Cargo.toml
@@ -26,3 +26,6 @@ tempfile = "3.0"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[lints.clippy]
+tabs_in_doc_comments = "allow"


### PR DESCRIPTION
## Summary
This PR adds clippy lint configurations across multiple crates to improve code quality standards while maintaining development flexibility.

## Changes
- Added `tabs_in_doc_comments = "allow"` rule across multiple crates
- Added `assign_op_pattern` and `mut_from_ref` allow rules for oso_kernel
- Reorganized oso_loader Cargo.toml metadata fields for consistency

## Impact
- Improves code quality standards
- Maintains flexibility for development patterns specific to OS development
- Ensures consistent linting across the workspace