### PR TITLE
refactor(dev-util): simplify cargo compilation options

### DIFF
--- a/oso_dev_util/src/decl_manage/crate_.rs
+++ b/oso_dev_util/src/decl_manage/crate_.rs
@@ -9,7 +9,7 @@ use crate::decl_manage::workspace::Workspace;
 use crate::decl_manage::workspace::WorkspaceAction;
 use crate::decl_manage::workspace::WorkspaceInfo;
 use crate::decl_manage::workspace::WorkspaceSurvey;
-use anyhow::anyhow;
+use anyhow::Context;
 use oso_dev_util_helper::cli::Run;
 use oso_dev_util_helper::fs::CARGO_CONFIG;
 use oso_dev_util_helper::fs::CARGO_MANIFEST;
@@ -243,7 +243,7 @@ impl PackageSurvey for OsoCrate {
 						None
 					}
 				},)
-				.ok_or(anyhow!("can't get host target tuple"),)
+				.context("can't get host target tuple",)
 		};
 
 		Ok(match self.cargo_conf() {
@@ -264,13 +264,12 @@ impl PackageSurvey for OsoCrate {
 	}
 
 	fn build_artifact(&self, opt: Option<impl CompileOpt,>,) -> Rslt<PathBuf,> {
-		let (target_tuple, build_mode,): (String, String,) = match opt {
-			Some(opt,) => (opt.target().into(), opt.build_mode().into(),),
+		let (arch, build_mode,): (String, String,) = match opt {
+			Some(opt,) => (opt.arch().into(), opt.build_mode().into(),),
 			None => (self.default_target()?.into(), BuildMode::default().as_ref().to_string(),),
 		};
 
-		let project_root =
-			project_root_path()?.join("target",).join(target_tuple,).join(build_mode,);
+		let project_root = project_root_path()?.join("target",).join(arch,).join(build_mode,);
 
 		Ok(project_root,)
 	}
@@ -284,7 +283,6 @@ pub trait CrateCalled: Eq + Sized + Clone + From<Self::F,> + Debug {
 }
 
 #[cfg(test)]
-#[cfg(false)]
 mod tests {
 	use super::*;
 	use std::path::PathBuf;
@@ -294,6 +292,7 @@ mod tests {
 	// Working around this by using the current directory which should exist
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_oso_crate_default() {
 		let default_crate = OsoCrate::default();
 		let default_path = default_crate.path();
@@ -302,6 +301,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_oso_crate_creation_with_current_dir() {
 		// Use current directory which should exist
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
@@ -310,6 +310,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_oso_crate_clone_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let original = OsoCrate::from(current_dir.clone(),);
@@ -320,6 +321,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_oso_crate_equality_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate1 = OsoCrate::from(current_dir.clone(),);
@@ -329,6 +331,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_info_path_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
@@ -338,6 +341,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_called_whoami_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
@@ -348,6 +352,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_called_path_buf_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
@@ -357,6 +362,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_from_pathbuf_conversion_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 
@@ -373,6 +379,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_oso_crate_chart_conversion_with_current_dir() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
@@ -389,6 +396,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_debug_implementation() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -402,6 +410,7 @@ mod tests {
 	// Test methods that don't require valid paths (they return Results)
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_action_methods_exist() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -410,13 +419,14 @@ mod tests {
 		// ignore `test` method because running it in test cause infinity loop
 		// ignore `run` too because this crate is library crate. nothing to run.
 		let _build_result = crate_obj.build();
-		let _check_result = crate_obj.ckeck();
+		let _check_result = crate_obj.check();
 		let _fmt_result = crate_obj.format();
 
 		// If we get here without compilation errors, the methods exist
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_action_with_methods_exist() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -433,6 +443,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_info_methods() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -446,6 +457,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_package_survey_methods() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -458,12 +470,10 @@ mod tests {
 		use crate::cargo::BuildMode;
 		use crate::cargo::Feature;
 		use crate::cargo::Opts;
-		use crate::cargo::RunsOn;
-		use crate::cargo::Target;
 		let opts = Opts {
 			build_mode:    BuildMode::Debug,
 			feature_flags: Vec::<Feature,>::new(),
-			target:        Target { runs_on: RunsOn::Oso, arch: Arch::Aarch64, },
+			arch:          Arch::Aarch64,
 		};
 		let _artifact_result = crate_obj.build_artifact(Some(opts,),);
 
@@ -471,6 +481,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_workspace_info_methods() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -482,6 +493,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_workspace_survey_land_on() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
@@ -497,6 +509,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_trait_implementations() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -514,6 +527,7 @@ mod tests {
 
 	// Test the survey methods that contain todo!() - they should panic
 	#[test]
+	#[ignore = "infinite loop"]
 	fn test_crate_survey_todo_methods() {
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);

--- a/oso_dev_util/src/decl_manage/package.rs
+++ b/oso_dev_util/src/decl_manage/package.rs
@@ -73,8 +73,6 @@ mod tests {
 		use crate::cargo::Arch;
 		use crate::cargo::Feature;
 		use crate::cargo::Opts;
-		use crate::cargo::RunsOn;
-		use crate::cargo::Target;
 
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -99,7 +97,7 @@ mod tests {
 		let opts = Opts {
 			build_mode:    BuildMode::Debug,
 			feature_flags: Vec::<Feature,>::new(),
-			target:        Target { runs_on: RunsOn::Oso, arch: Arch::Aarch64, },
+			arch:          Arch::Aarch64,
 		};
 
 		let artifact_result = crate_obj.build_artifact(Some(opts,),);
@@ -159,8 +157,6 @@ mod tests {
 		use crate::cargo::Arch;
 		use crate::cargo::Feature;
 		use crate::cargo::Opts;
-		use crate::cargo::RunsOn;
-		use crate::cargo::Target;
 
 		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
@@ -168,7 +164,7 @@ mod tests {
 		let opts = Opts {
 			build_mode:    BuildMode::Debug,
 			feature_flags: Vec::<Feature,>::new(),
-			target:        Target { runs_on: RunsOn::Linux, arch: Arch::Riscv64, },
+			arch:          Arch::Aarch64,
 		};
 
 		// Test build_artifact with CompileOpt

--- a/oso_dev_util/src/lib.rs
+++ b/oso_dev_util/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
 		use cargo::RunsOn;
 
 		let cli = Cli {
-			build_mode:    Some(BuildMode::Relese,),
+			build_mode:    Some(BuildMode::Release,),
 			feature_flags: None,
 			runs_on:       Some(RunsOn::Linux,),
 			arch:          Some(Arch::Riscv64,),
@@ -313,7 +313,7 @@ mod tests {
 		use cargo::RunsOn;
 
 		assert_eq!(BuildMode::Debug.as_ref(), "Debug");
-		assert_eq!(BuildMode::Relese.as_ref(), "Relese");
+		assert_eq!(BuildMode::Release.as_ref(), "Relese");
 
 		assert_eq!(RunsOn::Oso.as_ref(), "Oso");
 		assert_eq!(RunsOn::Linux.as_ref(), "Linux");
@@ -334,8 +334,8 @@ mod tests {
 		// BuildMode
 		assert!(BuildMode::Debug.is_debug());
 		assert!(!BuildMode::Debug.is_relese());
-		assert!(BuildMode::Relese.is_relese());
-		assert!(!BuildMode::Relese.is_debug());
+		assert!(BuildMode::Release.is_relese());
+		assert!(!BuildMode::Release.is_debug());
 
 		// RunsOn
 		assert!(RunsOn::Oso.is_oso());
@@ -411,7 +411,7 @@ mod tests {
 		let build_mode_values = BuildMode::value_variants();
 		assert_eq!(build_mode_values.len(), 2);
 		assert!(build_mode_values.contains(&BuildMode::Debug));
-		assert!(build_mode_values.contains(&BuildMode::Relese));
+		assert!(build_mode_values.contains(&BuildMode::Release));
 
 		let runs_on_values = RunsOn::value_variants();
 		assert_eq!(runs_on_values.len(), 4);
@@ -556,7 +556,7 @@ mod tests {
 		test_target_traits(Target::default(),);
 
 		// Test that Opts can be constructed with all combinations
-		let all_build_modes = [BuildMode::Debug, BuildMode::Relese,];
+		let all_build_modes = [BuildMode::Debug, BuildMode::Release,];
 		let all_runs_on = [RunsOn::Oso, RunsOn::Linux, RunsOn::Mac, RunsOn::Uefi,];
 		let all_archs = [Arch::Aarch64, Arch::Riscv64,];
 
@@ -614,7 +614,7 @@ mod tests {
 		use std::str::FromStr;
 
 		// Test round-trip conversions for all enum variants
-		let build_modes = [BuildMode::Debug, BuildMode::Relese,];
+		let build_modes = [BuildMode::Debug, BuildMode::Release,];
 		for mode in build_modes {
 			let as_str = mode.as_ref();
 			let parsed = BuildMode::from_str(as_str,).unwrap();
@@ -656,7 +656,7 @@ mod tests {
 		let mut opts_vec = Vec::new();
 		for i in 0..1000 {
 			let opts = Opts {
-				build_mode:    if i % 2 == 0 { BuildMode::Debug } else { BuildMode::Relese },
+				build_mode:    if i % 2 == 0 { BuildMode::Debug } else { BuildMode::Release },
 				feature_flags: Vec::<Feature,>::new(),
 				target:        Target {
 					runs_on: match i % 4 {

--- a/oso_dev_util/tests/integration_tests.rs
+++ b/oso_dev_util/tests/integration_tests.rs
@@ -37,7 +37,7 @@ fn test_cli_conversion() {
 #[test]
 fn test_compile_opt_trait() {
 	let opts = Opts {
-		build_mode:    BuildMode::Relese,
+		build_mode:    BuildMode::Release,
 		feature_flags: vec![],
 		target:        Target { runs_on: RunsOn::Mac, arch: Arch::Aarch64, },
 	};
@@ -99,7 +99,7 @@ fn test_enum_defaults() {
 
 #[test]
 fn test_enum_cloning() {
-	let build_mode = BuildMode::Relese;
+	let build_mode = BuildMode::Release;
 	let cloned = build_mode;
 	assert_eq!(build_mode, cloned);
 
@@ -115,7 +115,7 @@ fn test_enum_cloning() {
 #[test]
 fn test_enum_equality() {
 	assert_eq!(BuildMode::Debug, BuildMode::Debug);
-	assert_ne!(BuildMode::Debug, BuildMode::Relese);
+	assert_ne!(BuildMode::Debug, BuildMode::Release);
 
 	assert_eq!(RunsOn::Oso, RunsOn::Oso);
 	assert_ne!(RunsOn::Oso, RunsOn::Linux);
@@ -144,8 +144,8 @@ fn test_is_methods() {
 	// BuildMode
 	assert!(BuildMode::Debug.is_debug());
 	assert!(!BuildMode::Debug.is_relese());
-	assert!(BuildMode::Relese.is_relese());
-	assert!(!BuildMode::Relese.is_debug());
+	assert!(BuildMode::Release.is_relese());
+	assert!(!BuildMode::Release.is_debug());
 
 	// RunsOn
 	assert!(RunsOn::Oso.is_oso());
@@ -200,7 +200,7 @@ fn test_cli_all_combinations() {
 	// Test CLI with all possible combinations
 	use clap::ValueEnum;
 
-	for build_mode in [None, Some(BuildMode::Debug,), Some(BuildMode::Relese,),] {
+	for build_mode in [None, Some(BuildMode::Debug,), Some(BuildMode::Release,),] {
 		for runs_on in [
 			None,
 			Some(RunsOn::Oso,),
@@ -387,7 +387,7 @@ fn test_value_enum_completeness() {
 	let build_mode_variants = BuildMode::value_variants();
 	assert_eq!(build_mode_variants.len(), 2);
 	assert!(build_mode_variants.contains(&BuildMode::Debug));
-	assert!(build_mode_variants.contains(&BuildMode::Relese));
+	assert!(build_mode_variants.contains(&BuildMode::Release));
 
 	let runs_on_variants = RunsOn::value_variants();
 	assert_eq!(runs_on_variants.len(), 4);


### PR DESCRIPTION
This PR simplifies the oso_dev_util crate by removing unused abstractions and streamlining the compilation options API.

## Changes
- Remove unused runs_on() and target() methods from CompileOpt trait
- Replace Target with Arch in Opts struct for cleaner architecture handling  
- Streamline crate and package declaration management
- Update integration tests to reflect simplified API
- Improve code maintainability by removing redundant abstractions

## Impact
- Cleaner, more focused API for cargo compilation options
- Reduced complexity in the development utilities
- Better maintainability for future development