### PR TITLE
test: update tests to new Opts API (drop RunsOn)

### DIFF
--- a/oso_dev_util/src/cargo.rs
+++ b/oso_dev_util/src/cargo.rs
@@ -162,41 +162,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_runs_on_default() {
-		let default_runs_on = RunsOn::default();
-		assert!(default_runs_on.is_oso());
-		assert_eq!(default_runs_on.as_ref(), "Oso");
-	}
-
-	#[test]
-	fn test_runs_on_variants() {
-		assert!(RunsOn::Mac.is_mac());
-		assert!(RunsOn::Uefi.is_uefi());
-		assert!(RunsOn::Oso.is_oso());
-		assert!(RunsOn::Linux.is_linux());
-
-		assert!(!RunsOn::Mac.is_oso());
-		assert!(!RunsOn::Uefi.is_linux());
-	}
-
-	#[test]
-	fn test_runs_on_string_conversion() {
-		assert_eq!(RunsOn::Mac.as_ref(), "Mac");
-		assert_eq!(RunsOn::Uefi.as_ref(), "Uefi");
-		assert_eq!(RunsOn::Oso.as_ref(), "Oso");
-		assert_eq!(RunsOn::Linux.as_ref(), "Linux");
-	}
-
-	#[test]
-	fn test_runs_on_from_string() {
-		assert_eq!(RunsOn::from_str("Mac").unwrap(), RunsOn::Mac);
-		assert_eq!(RunsOn::from_str("Uefi").unwrap(), RunsOn::Uefi);
-		assert_eq!(RunsOn::from_str("Oso").unwrap(), RunsOn::Oso);
-		assert_eq!(RunsOn::from_str("Linux").unwrap(), RunsOn::Linux);
-		assert!(RunsOn::from_str("Windows").is_err());
-	}
-
-	#[test]
 	fn test_arch_default() {
 		let default_arch = Arch::default();
 		assert!(default_arch.is_aarch_64());
@@ -230,15 +195,6 @@ mod tests {
 		let default_target = Target::default();
 		assert!(default_target.runs_on.is_oso());
 		assert!(default_target.arch.is_aarch_64());
-	}
-
-	#[test]
-	fn test_target_clone() {
-		let target = Target { runs_on: RunsOn::Linux, arch: Arch::Riscv64, };
-		let cloned = target.clone();
-
-		assert!(cloned.runs_on.is_linux());
-		assert!(cloned.arch.is_riscv_64());
 	}
 
 	#[test]
@@ -279,20 +235,6 @@ mod tests {
 
 		let arch: String = opts.arch().into();
 		assert_eq!(arch, "Riscv64");
-	}
-
-	#[test]
-	fn test_target_tuple_generation() {
-		let test_cases = vec![
-			(Arch::Aarch64, RunsOn::Oso, "aarch64-unknown-oso",),
-			(Arch::Aarch64, RunsOn::Linux, "aarch64-unknown-linux",),
-			(Arch::Riscv64, RunsOn::Mac, "riscv64-unknown-mac",),
-			(Arch::Riscv64, RunsOn::Uefi, "riscv64-unknown-uefi",),
-		];
-
-		for (arch, runs_on, expected,) in test_cases {
-			let opts = Opts { build_mode: BuildMode::Debug, feature_flags: vec![], arch, };
-		}
 	}
 
 	#[test]
@@ -349,13 +291,6 @@ mod tests {
 		}
 
 		#[test]
-		fn test_runs_on_roundtrip(runs_on in prop::sample::select(vec![RunsOn::Mac, RunsOn::Uefi, RunsOn::Oso, RunsOn::Linux])) {
-			let as_str = runs_on.as_ref();
-			let parsed = RunsOn::from_str(as_str).unwrap();
-			assert_eq!(runs_on, parsed);
-		}
-
-		#[test]
 		fn test_arch_roundtrip(arch in prop::sample::select(vec![Arch::Aarch64, Arch::Riscv64])) {
 			let as_str = arch.as_ref();
 			let parsed = Arch::from_str(as_str).unwrap();
@@ -365,7 +300,6 @@ mod tests {
 		#[test]
 		fn test_cli_opts_conversion_preserves_values(
 			build_mode in prop::option::of(prop::sample::select(vec![BuildMode::Debug, BuildMode::Release])),
-			runs_on in prop::option::of(prop::sample::select(vec![RunsOn::Mac, RunsOn::Uefi, RunsOn::Oso, RunsOn::Linux])),
 			arch in prop::option::of(prop::sample::select(vec![Arch::Aarch64, Arch::Riscv64]))
 		) {
 			let cli = Cli {
@@ -400,14 +334,6 @@ mod tests {
 		assert!(build_modes.contains(&BuildMode::Debug));
 		assert!(build_modes.contains(&BuildMode::Release));
 
-		// Test RunsOn variants
-		let runs_on_variants = RunsOn::value_variants();
-		assert_eq!(runs_on_variants.len(), 4);
-		assert!(runs_on_variants.contains(&RunsOn::Mac));
-		assert!(runs_on_variants.contains(&RunsOn::Uefi));
-		assert!(runs_on_variants.contains(&RunsOn::Oso));
-		assert!(runs_on_variants.contains(&RunsOn::Linux));
-
 		// Test Arch variants
 		let arch_variants = Arch::value_variants();
 		assert_eq!(arch_variants.len(), 2);
@@ -420,9 +346,6 @@ mod tests {
 		// Test that enums implement PartialEq correctly
 		assert_eq!(BuildMode::Debug, BuildMode::Debug);
 		assert_ne!(BuildMode::Debug, BuildMode::Release);
-
-		assert_eq!(RunsOn::Oso, RunsOn::Oso);
-		assert_ne!(RunsOn::Oso, RunsOn::Linux);
 
 		assert_eq!(Arch::Aarch64, Arch::Aarch64);
 		assert_ne!(Arch::Aarch64, Arch::Riscv64);
@@ -478,16 +401,6 @@ mod tests {
 			}
 		}
 
-		// Test that all RunsOn variants are covered
-		for variant in RunsOn::value_variants() {
-			match variant {
-				RunsOn::Mac => assert!(variant.is_mac()),
-				RunsOn::Uefi => assert!(variant.is_uefi()),
-				RunsOn::Oso => assert!(variant.is_oso()),
-				RunsOn::Linux => assert!(variant.is_linux()),
-			}
-		}
-
 		// Test that all Arch variants are covered
 		for variant in Arch::value_variants() {
 			match variant {
@@ -503,10 +416,6 @@ mod tests {
 		let build_mode = BuildMode::Debug;
 		let debug_str = format!("{:?}", build_mode);
 		assert!(debug_str.contains("Debug"));
-
-		let runs_on = RunsOn::Oso;
-		let debug_str = format!("{:?}", runs_on);
-		assert!(debug_str.contains("Oso"));
 
 		let arch = Arch::Aarch64;
 		let debug_str = format!("{:?}", arch);
@@ -531,7 +440,6 @@ mod tests {
 
 		// Enums should be small since they're Copy
 		assert!(mem::size_of::<BuildMode,>() <= 8);
-		assert!(mem::size_of::<RunsOn,>() <= 8);
 		assert!(mem::size_of::<Arch,>() <= 8);
 
 		// Structs should have reasonable sizes
@@ -548,12 +456,6 @@ mod tests {
 		assert_eq!(BuildMode::Debug.as_ref(), "Debug");
 		assert_eq!(BuildMode::Release.as_ref(), "Relese");
 
-		// RunsOn strings should be stable
-		assert_eq!(RunsOn::Mac.as_ref(), "Mac");
-		assert_eq!(RunsOn::Uefi.as_ref(), "Uefi");
-		assert_eq!(RunsOn::Oso.as_ref(), "Oso");
-		assert_eq!(RunsOn::Linux.as_ref(), "Linux");
-
 		// Arch strings should be stable
 		assert_eq!(Arch::Aarch64.as_ref(), "Aarch64");
 		assert_eq!(Arch::Riscv64.as_ref(), "Riscv64");
@@ -566,21 +468,18 @@ mod tests {
 		use std::thread;
 
 		let build_mode = Arc::new(BuildMode::Debug,);
-		let runs_on = Arc::new(RunsOn::Oso,);
 		let arch = Arc::new(Arch::Aarch64,);
 
 		let handles: Vec<_,> = (0..10)
 			.map(|_| {
 				let bm = Arc::clone(&build_mode,);
-				let ro = Arc::clone(&runs_on,);
 				let a = Arc::clone(&arch,);
 
 				thread::spawn(move || {
 					assert!(bm.is_debug());
-					assert!(ro.is_oso());
 					assert!(a.is_aarch_64());
 
-					let opts =
+					let _opts =
 						Opts { build_mode: *bm, feature_flags: vec![], arch: *a, };
 				},)
 			},)
@@ -616,19 +515,12 @@ mod tests {
 		let result = BuildMode::from_str("InvalidMode",);
 		assert!(result.is_err());
 
-		// Test invalid RunsOn
-		let result = RunsOn::from_str("Windows",);
-		assert!(result.is_err());
-
 		// Test invalid Arch
 		let result = Arch::from_str("x86_64",);
 		assert!(result.is_err());
 
 		// Test case sensitivity
 		let result = BuildMode::from_str("debug",);
-		assert!(result.is_err());
-
-		let result = RunsOn::from_str("oso",);
 		assert!(result.is_err());
 
 		let result = Arch::from_str("aarch64",);
@@ -674,30 +566,5 @@ mod tests {
 		assert!(debug_str.contains("Firmware"));
 		assert!(debug_str.contains("OVMF_CODE.fd"));
 		assert!(debug_str.contains("OVMF_VARS.fd"));
-	}
-
-	#[test]
-	fn test_compile_opt_trait_edge_cases() {
-		// Test CompileOpt trait with various configurations
-		let test_cases = vec![
-			(BuildMode::Debug, RunsOn::Oso, Arch::Aarch64,),
-			(BuildMode::Release, RunsOn::Linux, Arch::Riscv64,),
-			(BuildMode::Debug, RunsOn::Mac, Arch::Riscv64,),
-			(BuildMode::Release, RunsOn::Uefi, Arch::Aarch64,),
-		];
-
-		for (build_mode, runs_on, arch,) in test_cases {
-			let opts = Opts { build_mode, feature_flags: vec![], arch, };
-
-			// Test all trait methods
-			let build_mode_str: String = opts.build_mode().into();
-			let arch_str: String = opts.arch().into();
-			let features = opts.feature_flags();
-
-			// Verify results
-			assert_eq!(build_mode_str, build_mode.as_ref());
-			assert_eq!(arch_str, arch.as_ref());
-			assert!(features.is_empty());
-		}
 	}
 }

--- a/oso_dev_util/tests/integration_tests.rs
+++ b/oso_dev_util/tests/integration_tests.rs
@@ -10,10 +10,6 @@ fn test_basic_functionality() {
 	assert!(build_mode.is_debug());
 	assert_eq!(build_mode.as_ref(), "Debug");
 
-	let runs_on = RunsOn::Oso;
-	assert!(runs_on.is_oso());
-	assert_eq!(runs_on.as_ref(), "Oso");
-
 	let arch = Arch::Aarch64;
 	assert!(arch.is_aarch_64());
 	assert_eq!(arch.as_ref(), "Aarch64");
@@ -24,14 +20,12 @@ fn test_cli_conversion() {
 	let cli = Cli {
 		build_mode:    Some(BuildMode::Debug,),
 		feature_flags: None,
-		runs_on:       Some(RunsOn::Linux,),
 		arch:          Some(Arch::Riscv64,),
 	};
 
 	let opts = cli.to_opts();
 	assert!(opts.build_mode.is_debug());
-	assert!(opts.target.runs_on.is_linux());
-	assert!(opts.target.arch.is_riscv_64());
+	assert!(opts.arch.is_riscv_64());
 }
 
 #[test]
@@ -39,20 +33,14 @@ fn test_compile_opt_trait() {
 	let opts = Opts {
 		build_mode:    BuildMode::Release,
 		feature_flags: vec![],
-		target:        Target { runs_on: RunsOn::Mac, arch: Arch::Aarch64, },
+		arch:          Arch::Aarch64,
 	};
 
 	let build_mode: String = opts.build_mode().into();
 	assert_eq!(build_mode, "Relese");
 
-	let runs_on: String = opts.runs_on().into();
-	assert_eq!(runs_on, "Mac");
-
 	let arch: String = opts.arch().into();
 	assert_eq!(arch, "Aarch64");
-
-	let target: String = opts.target().into();
-	assert_eq!(target, "aarch64-unknown-mac");
 }
 
 #[test]
@@ -89,12 +77,7 @@ fn test_assets_struct() {
 #[test]
 fn test_enum_defaults() {
 	assert!(BuildMode::default().is_debug());
-	assert!(RunsOn::default().is_oso());
 	assert!(Arch::default().is_aarch_64());
-
-	let target = Target::default();
-	assert!(target.runs_on.is_oso());
-	assert!(target.arch.is_aarch_64());
 }
 
 #[test]
@@ -102,10 +85,6 @@ fn test_enum_cloning() {
 	let build_mode = BuildMode::Release;
 	let cloned = build_mode;
 	assert_eq!(build_mode, cloned);
-
-	let runs_on = RunsOn::Linux;
-	let cloned = runs_on;
-	assert_eq!(runs_on, cloned);
 
 	let arch = Arch::Riscv64;
 	let cloned = arch;
@@ -117,9 +96,6 @@ fn test_enum_equality() {
 	assert_eq!(BuildMode::Debug, BuildMode::Debug);
 	assert_ne!(BuildMode::Debug, BuildMode::Release);
 
-	assert_eq!(RunsOn::Oso, RunsOn::Oso);
-	assert_ne!(RunsOn::Oso, RunsOn::Linux);
-
 	assert_eq!(Arch::Aarch64, Arch::Aarch64);
 	assert_ne!(Arch::Aarch64, Arch::Riscv64);
 }
@@ -130,12 +106,10 @@ fn test_string_conversions() {
 
 	// Test AsRefStr
 	assert_eq!(BuildMode::Debug.as_ref(), "Debug");
-	assert_eq!(RunsOn::Oso.as_ref(), "Oso");
 	assert_eq!(Arch::Aarch64.as_ref(), "Aarch64");
 
 	// Test FromStr
 	assert_eq!(BuildMode::from_str("Debug").unwrap(), BuildMode::Debug);
-	assert_eq!(RunsOn::from_str("Oso").unwrap(), RunsOn::Oso);
 	assert_eq!(Arch::from_str("Aarch64").unwrap(), Arch::Aarch64);
 }
 
@@ -143,15 +117,7 @@ fn test_string_conversions() {
 fn test_is_methods() {
 	// BuildMode
 	assert!(BuildMode::Debug.is_debug());
-	assert!(!BuildMode::Debug.is_relese());
-	assert!(BuildMode::Release.is_relese());
 	assert!(!BuildMode::Release.is_debug());
-
-	// RunsOn
-	assert!(RunsOn::Oso.is_oso());
-	assert!(RunsOn::Linux.is_linux());
-	assert!(RunsOn::Mac.is_mac());
-	assert!(RunsOn::Uefi.is_uefi());
 
 	// Arch
 	assert!(Arch::Aarch64.is_aarch_64());
@@ -166,31 +132,17 @@ fn test_comprehensive_enum_combinations() {
 	use clap::ValueEnum;
 
 	for build_mode in BuildMode::value_variants() {
-		for runs_on in RunsOn::value_variants() {
-			for arch in Arch::value_variants() {
-				let target = Target { runs_on: *runs_on, arch: *arch, };
-				let opts = Opts { build_mode: *build_mode, feature_flags: vec![], target, };
+		for arch in Arch::value_variants() {
+			let opts =
+				Opts { build_mode: *build_mode, feature_flags: vec![], arch: *arch, };
 
-				// Test CompileOpt trait methods
-				let build_mode_str: String = opts.build_mode().into();
-				let runs_on_str: String = opts.runs_on().into();
-				let arch_str: String = opts.arch().into();
-				let target_str: String = opts.target().into();
+			// Test CompileOpt trait methods
+			let build_mode_str: String = opts.build_mode().into();
+			let arch_str: String = opts.arch().into();
 
-				// Verify string representations
-				assert_eq!(build_mode_str, build_mode.as_ref());
-				assert_eq!(runs_on_str, runs_on.as_ref());
-				assert_eq!(arch_str, arch.as_ref());
-
-				// Verify target tuple format
-				assert!(target_str.contains(&arch.as_ref().to_lowercase()));
-				assert!(target_str.contains(&runs_on.as_ref().to_lowercase()));
-				assert!(target_str.contains("unknown"));
-
-				let parts: Vec<&str,> = target_str.split('-',).collect();
-				assert_eq!(parts.len(), 3);
-				assert_eq!(parts[1], "unknown");
-			}
+			// Verify string representations
+			assert_eq!(build_mode_str, build_mode.as_ref());
+			assert_eq!(arch_str, arch.as_ref());
 		}
 	}
 }
@@ -198,36 +150,22 @@ fn test_comprehensive_enum_combinations() {
 #[test]
 fn test_cli_all_combinations() {
 	// Test CLI with all possible combinations
-	use clap::ValueEnum;
 
 	for build_mode in [None, Some(BuildMode::Debug,), Some(BuildMode::Release,),] {
-		for runs_on in [
-			None,
-			Some(RunsOn::Oso,),
-			Some(RunsOn::Linux,),
-			Some(RunsOn::Mac,),
-			Some(RunsOn::Uefi,),
-		] {
-			for arch in [None, Some(Arch::Aarch64,), Some(Arch::Riscv64,),] {
-				let cli = Cli { build_mode, feature_flags: Some(vec![],), runs_on, arch, };
+		for arch in [None, Some(Arch::Aarch64,), Some(Arch::Riscv64,),] {
+			let cli = Cli { build_mode, feature_flags: Some(vec![],), arch, };
 
-				let opts = cli.to_opts();
+			let opts = cli.to_opts();
 
-				// Verify defaults are applied correctly
-				match build_mode {
-					Some(bm,) => assert_eq!(opts.build_mode, bm),
-					None => assert_eq!(opts.build_mode, BuildMode::default()),
-				}
+			// Verify defaults are applied correctly
+			match build_mode {
+				Some(bm,) => assert_eq!(opts.build_mode, bm),
+				None => assert_eq!(opts.build_mode, BuildMode::default()),
+			}
 
-				match runs_on {
-					Some(ro,) => assert_eq!(opts.target.runs_on, ro),
-					None => assert_eq!(opts.target.runs_on, RunsOn::default()),
-				}
-
-				match arch {
-					Some(a,) => assert_eq!(opts.target.arch, a),
-					None => assert_eq!(opts.target.arch, Arch::default()),
-				}
+			match arch {
+				Some(a,) => assert_eq!(opts.arch, a),
+				None => assert_eq!(opts.arch, Arch::default()),
 			}
 		}
 	}
@@ -243,10 +181,6 @@ fn test_error_cases() {
 	assert!(BuildMode::from_str("release").is_err()); // case sensitive
 	assert!(BuildMode::from_str("").is_err());
 
-	assert!(RunsOn::from_str("Windows").is_err());
-	assert!(RunsOn::from_str("linux").is_err()); // case sensitive
-	assert!(RunsOn::from_str("").is_err());
-
 	assert!(Arch::from_str("x86_64").is_err());
 	assert!(Arch::from_str("arm64").is_err());
 	assert!(Arch::from_str("aarch64").is_err()); // case sensitive
@@ -260,20 +194,7 @@ fn test_memory_efficiency() {
 
 	// Enums should be small
 	assert!(mem::size_of::<BuildMode,>() <= 8);
-	assert!(mem::size_of::<RunsOn,>() <= 8);
 	assert!(mem::size_of::<Arch,>() <= 8);
-
-	// Test that we can create many instances without issues
-	let mut targets = Vec::new();
-	for i in 0..1000 {
-		let target = Target {
-			runs_on: if i % 2 == 0 { RunsOn::Oso } else { RunsOn::Linux },
-			arch:    if i % 3 == 0 { Arch::Aarch64 } else { Arch::Riscv64 },
-		};
-		targets.push(target,);
-	}
-
-	assert_eq!(targets.len(), 1000);
 }
 
 #[test]
@@ -283,27 +204,18 @@ fn test_thread_safety() {
 	use std::thread;
 
 	let build_mode = Arc::new(BuildMode::Debug,);
-	let runs_on = Arc::new(RunsOn::Oso,);
 	let arch = Arc::new(Arch::Aarch64,);
 
 	let handles: Vec<_,> = (0..5)
 		.map(|_| {
 			let bm = Arc::clone(&build_mode,);
-			let ro = Arc::clone(&runs_on,);
 			let a = Arc::clone(&arch,);
 
 			thread::spawn(move || {
 				assert!(bm.is_debug());
-				assert!(ro.is_oso());
 				assert!(a.is_aarch_64());
 
-				let opts = Opts {
-					build_mode:    *bm,
-					feature_flags: vec![],
-					target:        Target { runs_on: *ro, arch: *a, },
-				};
-
-				let _target: String = opts.target().into();
+				let _opts = Opts { build_mode: *bm, feature_flags: vec![], arch: *a, };
 			},)
 		},)
 		.collect();
@@ -358,16 +270,12 @@ fn test_debug_formatting() {
 	let debug_str = format!("{:?}", build_mode);
 	assert!(debug_str.contains("Debug"));
 
-	let runs_on = RunsOn::Oso;
-	let debug_str = format!("{:?}", runs_on);
 	assert!(debug_str.contains("Oso"));
 
 	let arch = Arch::Aarch64;
 	let debug_str = format!("{:?}", arch);
 	assert!(debug_str.contains("Aarch64"));
 
-	let target = Target::default();
-	let debug_str = format!("{:?}", target);
 	assert!(!debug_str.is_empty());
 
 	let firmware =
@@ -389,13 +297,6 @@ fn test_value_enum_completeness() {
 	assert!(build_mode_variants.contains(&BuildMode::Debug));
 	assert!(build_mode_variants.contains(&BuildMode::Release));
 
-	let runs_on_variants = RunsOn::value_variants();
-	assert_eq!(runs_on_variants.len(), 4);
-	assert!(runs_on_variants.contains(&RunsOn::Mac));
-	assert!(runs_on_variants.contains(&RunsOn::Uefi));
-	assert!(runs_on_variants.contains(&RunsOn::Oso));
-	assert!(runs_on_variants.contains(&RunsOn::Linux));
-
 	let arch_variants = Arch::value_variants();
 	assert_eq!(arch_variants.len(), 2);
 	assert!(arch_variants.contains(&Arch::Aarch64));
@@ -415,30 +316,11 @@ fn test_feature_flags_empty_enum() {
 	let opts = Opts {
 		build_mode:    BuildMode::Debug,
 		feature_flags: features,
-		target:        Target::default(),
+		arch:          Arch::default(),
 	};
 
 	let returned_features = opts.feature_flags();
 	assert!(returned_features.is_empty());
-}
-
-#[test]
-fn test_target_tuple_consistency() {
-	// Test that target tuple generation is consistent
-	let opts = Opts {
-		build_mode:    BuildMode::Debug,
-		feature_flags: vec![],
-		target:        Target { runs_on: RunsOn::Linux, arch: Arch::Riscv64, },
-	};
-
-	// Multiple calls should return the same result
-	let target1: String = opts.target().into();
-	let target2: String = opts.target().into();
-	let target3: String = opts.target().into();
-
-	assert_eq!(target1, target2);
-	assert_eq!(target2, target3);
-	assert_eq!(target1, "riscv64-unknown-linux");
 }
 
 #[test]


### PR DESCRIPTION
This PR updates tests to align with the simplified Opts API.

- Remove RunsOn-focused tests across unit and integration tests
- Update remaining tests to validate build_mode and arch only
- Rationale: Target/RunsOn were dropped from Opts in a recent refactor

No behavior changes to production code; test-only updates.