### PR TITLE
refactor(graphic): simplify stride guard using if-let chain

### DIFF
--- a/oso_no_std_shared/src/bridge/graphic.rs
+++ b/oso_no_std_shared/src/bridge/graphic.rs
@@ -513,10 +513,10 @@ impl FrameBufConf {
 		}
 
 		// Check if stride is reasonable
-		if let Some(bytes_per_pixel,) = self.pixel_format.bytes_per_pixel() {
-			if self.stride < self.width * bytes_per_pixel {
-				return false;
-			}
+		if let Some(bytes_per_pixel,) = self.pixel_format.bytes_per_pixel()
+			&& self.stride < self.width * bytes_per_pixel
+		{
+			return false;
 		}
 
 		// Check if size is sufficient


### PR DESCRIPTION
Refactor graphic frame buffer config check.

- Combine bytes_per_pixel availability and stride bounds into a single guard
- Maintains existing behavior; improves clarity
- Scope: oso_no_std_shared FrameBufConf validation
