### PR TITLE
chore(ci): set GH_TOKEN for analyze-prs job

### DIFF
--- a/.github/workflows/batch-ai-doctor.yml
+++ b/.github/workflows/batch-ai-doctor.yml
@@ -85,6 +85,8 @@ jobs:
    analyze-prs:
       needs: scan-prs
       runs-on: ubuntu-latest
+      env:
+         GH_TOKEN: ${{ github.token }}
       if: ${{ needs.scan-prs.outputs.pr_list != '[]' }}
       strategy:
          matrix:


### PR DESCRIPTION
This PR updates the batch-ai-doctor GitHub Actions workflow.

- Sets GH_TOKEN for the analyze-prs job using ${{ github.token }}
- Enables authenticated gh/GitHub API calls within the job
- Minimizes CI failures due to permission or rate limits