### PR TITLE
feat(crates): implement CrateSurvey ops and simplify WorkspaceSurvey

### DIFF
--- a/oso_dev_util/src/decl_manage/workspace.rs
+++ b/oso_dev_util/src/decl_manage/workspace.rs
@@ -85,9 +85,7 @@ pub trait WorkspaceAction: WorkspaceInfo + CrateAction {
 	}
 }
 
-pub trait WorkspaceSurvey: WorkspaceInfo + CrateSurvey {
-	fn land_on(&mut self, on: impl CrateCalled,);
-}
+pub trait WorkspaceSurvey: WorkspaceInfo + CrateSurvey {}
 
 /// Trait for managing OSO workspace operations
 ///

--- a/oso_dev_util/src/lib.rs
+++ b/oso_dev_util/src/lib.rs
@@ -66,6 +66,7 @@
 
 #![feature(exit_status_error)]
 #![feature(proc_macro_hygiene)]
+#![feature(if_let_guard)]
 
 use anyhow::Result as Rslt;
 


### PR DESCRIPTION
- Implement has_parent using search_upstream_at and CARGO_MANIFEST\n- Implement fix to align Cargo.toml package.name with directory name\n- Add land_on and go_parent behaviors for crate navigation\n- Provide name() on CrateInfo; enable if_let_guard feature\n- Simplify WorkspaceSurvey trait since land_on is provided via CrateSurvey\n- Update tests to assert success paths\n- References: N/A