### PR TITLE
chore(deps): move aquamarine to runtime dependencies

### DIFF
--- a/oso_dev_util/Cargo.toml
+++ b/oso_dev_util/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "*"
+aquamarine = "*"
 clap = { version = "*", features = ["derive"] }
 clap_derive = { version = "4.0.0-rc.1" }
 colored = "*"
@@ -16,4 +17,3 @@ toml = { version = "*", features = ["parse"] }
 
 [dev-dependencies]
 proptest = "*"
-aquamarine = "*"


### PR DESCRIPTION
- Move aquamarine from dev-dependencies to dependencies\n- Ensures crate compiles/docs as needed in downstream contexts\n- Keeps dependency specification consistent\n- References: N/A