### PR TITLE
refactor(oso_dev_util): streamline decl and fs utilities

### DIFF
--- a/oso_dev_util/src/cargo.rs
+++ b/oso_dev_util/src/cargo.rs
@@ -17,7 +17,12 @@ pub trait CompileOpt {
 }
 
 #[features]
-#[derive(strum_macros::AsRefStr, strum_macros::EnumIs, strum_macros::EnumString, Clone,)]
+#[derive(
+	strum_macros::AsRefStr,
+	strum_macros::EnumIs,
+	strum_macros::EnumString,
+	Clone,
+)]
 pub enum Feature {}
 
 pub struct Opts {
@@ -103,7 +108,10 @@ impl Runtime {
 		host_tuple()?
 			.split('-',)
 			.next()
-			.context("target tuple for host does not include `-`. that is not usual.",)
+			.context(
+				"target tuple for host does not include `-`. that is not \
+				 usual.",
+			)
 			.map(Runtime::from_str,)
 	}
 }
@@ -228,7 +236,11 @@ pub fn host_tuple() -> Rslt<String,> {
 	target
 		.lines()
 		.find_map(|l| {
-			if l.contains("host: ",) { Some(l.replace("host: ", "",).to_string(),) } else { None }
+			if l.contains("host: ",) {
+				Some(l.replace("host: ", "",).to_string(),)
+			} else {
+				None
+			}
 		},)
 		.context("can't get host target tuple",)
 }
@@ -311,7 +323,11 @@ mod tests {
 
 	#[test]
 	fn test_cli_to_opts_with_defaults() {
-		let cli = Cli { build_mode: None, feature_flags: None, arch: None, };
+		let cli = Cli {
+			build_mode:    None,
+			feature_flags: None,
+			arch:          None,
+		};
 
 		let opts = cli.to_opts();
 		assert!(opts.build_mode.is_debug());
@@ -349,7 +365,10 @@ mod tests {
 
 	#[test]
 	fn test_firmware_debug() {
-		let firmware = Firmware { code: PathBuf::from("/code",), vars: PathBuf::from("/vars",), };
+		let firmware = Firmware {
+			code: PathBuf::from("/code",),
+			vars: PathBuf::from("/vars",),
+		};
 
 		let debug_str = format!("{:?}", firmware);
 		assert!(debug_str.contains("Firmware"));
@@ -378,7 +397,8 @@ mod tests {
 		assert!(features.is_empty());
 
 		// Test that Feature implements required traits
-		let _phantom: std::marker::PhantomData<Feature,> = std::marker::PhantomData;
+		let _phantom: std::marker::PhantomData<Feature,> =
+			std::marker::PhantomData;
 	}
 
 	// Property-based tests
@@ -523,8 +543,10 @@ mod tests {
 
 		assert!(!debug_str.is_empty());
 
-		let firmware =
-			Firmware { code: PathBuf::from("/test/code",), vars: PathBuf::from("/test/vars",), };
+		let firmware = Firmware {
+			code: PathBuf::from("/test/code",),
+			vars: PathBuf::from("/test/vars",),
+		};
 		let debug_str = format!("{:?}", firmware);
 		assert!(debug_str.contains("Firmware"));
 		assert!(debug_str.contains("/test/code"));
@@ -576,8 +598,11 @@ mod tests {
 					assert!(bm.is_debug());
 					assert!(a.is_aarch_64());
 
-					let _opts =
-						Opts { build_mode: *bm, feature_flags: vec![], arch: *a, };
+					let _opts = Opts {
+						build_mode:    *bm,
+						feature_flags: vec![],
+						arch:          *a,
+					};
 				},)
 			},)
 			.collect();
@@ -596,7 +621,11 @@ mod tests {
 		let _parser = Cli::command();
 
 		// Test default CLI
-		let cli = Cli { build_mode: None, feature_flags: None, arch: None, };
+		let cli = Cli {
+			build_mode:    None,
+			feature_flags: None,
+			arch:          None,
+		};
 
 		let opts = cli.to_opts();
 		assert!(opts.build_mode.is_debug());

--- a/oso_dev_util/src/decl_manage.rs
+++ b/oso_dev_util/src/decl_manage.rs
@@ -28,8 +28,12 @@ pub struct OsoCargoInterface {
 impl CargoCrate for OsoCargoInterface {
 	fn specified_target(&self,) -> Rslt<impl Into<String,>,> {
 		let search_rslt = search_in_with(&self.ws.path(), |entry| {
-			let file_name =
-				entry.as_ref().expect("file io error",).file_name().to_string_lossy().to_string();
+			let file_name = entry
+				.as_ref()
+				.expect("file io error",)
+				.file_name()
+				.to_string_lossy()
+				.to_string();
 			let arch = self.opt.arch().into();
 
 			file_name.contains(&arch,) && file_name.ends_with(".json",)

--- a/oso_dev_util/src/decl_manage/crate_.rs
+++ b/oso_dev_util/src/decl_manage/crate_.rs
@@ -45,7 +45,10 @@ pub trait CrateSurvey: CrateInfo {
 			&& *name != true_name
 		{
 			*name = true_name;
-			std::fs::write(self.path().join(CARGO_MANIFEST,), toml::to_string(&manifest,)?,)?;
+			std::fs::write(
+				self.path().join(CARGO_MANIFEST,),
+				toml::to_string(&manifest,)?,
+			)?;
 		};
 		Ok((),)
 	}
@@ -92,11 +95,16 @@ pub trait CrateAction: CrateInfo {
 	fn fmt_with(&self, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),> {
 		self.cargo_xxx_with("fmt", opt,)
 	}
-	fn cargo_xxx_with(&self, cmd: impl AsRef<OsStr,>, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),> {
+	fn cargo_xxx_with(
+		&self,
+		cmd: impl AsRef<OsStr,>,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),> {
 		let mut cargo = Command::new("cargo",);
 		let cargo = cargo.arg(cmd,);
 
-		let opt: Vec<_,> = opt.iter().filter(|s| !s.as_ref().is_empty(),).collect();
+		let opt: Vec<_,> =
+			opt.iter().filter(|s| !s.as_ref().is_empty(),).collect();
 		if !opt.is_empty() {
 			cargo.args(opt,);
 		}
@@ -127,13 +135,14 @@ pub trait CrateInfo: CrateCalled {
 	}
 
 	/// return path to the crate
-	/// return type is not Result because macro ensures that path exists and self has path in
-	/// compile time
+	/// return type is not Result because macro ensures that path exists and
+	/// self has path in compile time
 	fn path(&self,) -> PathBuf;
 
 	fn toml(&self,) -> Rslt<toml::Table,> {
 		let cargo_toml = self.path().join(CARGO_MANIFEST,);
-		read_toml(cargo_toml,).unwrap_or_else(|| panic!("{CARGO_MANIFEST} must exist"),)
+		read_toml(cargo_toml,)
+			.unwrap_or_else(|| panic!("{CARGO_MANIFEST} must exist"),)
 	}
 
 	fn cargo_conf(&self,) -> Option<Rslt<toml::Table,>,> {
@@ -184,7 +193,8 @@ impl CrateSurvey for OsoCrate {
 	fn go_parent(&mut self,) -> Rslt<(),> {
 		if self.has_parent()? {
 			let parent = self.path();
-			let parent = parent.parent().ok_or(anyhow!("can't find parent dir"),)?;
+			let parent =
+				parent.parent().ok_or(anyhow!("can't find parent dir"),)?;
 			let parent = OsoCrateChart::from(parent.to_path_buf(),);
 			self.land_on(parent,);
 			Ok((),)
@@ -240,12 +250,17 @@ impl WorkspaceInfo for OsoCrate {
 	}
 
 	#[allow(refining_impl_trait)]
-	fn members_with_target(&self, target: impl Into<String,> + Clone,) -> Vec<OsoCrate,> {
+	fn members_with_target(
+		&self,
+		target: impl Into<String,> + Clone,
+	) -> Vec<OsoCrate,> {
 		self.members()
 			.into_iter()
 			.filter(|c| {
-				let dflt_target: String =
-					c.default_target().expect("failed to determine default target",).into();
+				let dflt_target: String = c
+					.default_target()
+					.expect("failed to determine default target",)
+					.into();
 				let target: String = target.clone().into();
 				dflt_target == target
 			},)
@@ -288,9 +303,10 @@ mod tests {
 	use super::*;
 	use std::path::PathBuf;
 
-	// Note: The FromPathBuf macro validates paths and panics on non-existent paths
-	// This is a suspected program bug - tests should be able to use mock paths
-	// Working around this by using the current directory which should exist
+	// Note: The FromPathBuf macro validates paths and panics on non-existent
+	// paths This is a suspected program bug - tests should be able to use mock
+	// paths Working around this by using the current directory which should
+	// exist
 
 	#[test]
 	fn test_oso_crate_default() {
@@ -303,14 +319,16 @@ mod tests {
 	#[test]
 	fn test_oso_crate_creation_with_current_dir() {
 		// Use current directory which should exist
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 		assert_eq!(crate_obj.path(), current_dir);
 	}
 
 	#[test]
 	fn test_oso_crate_clone_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let original = OsoCrate::from(current_dir.clone(),);
 		let cloned = original.clone();
 
@@ -320,7 +338,8 @@ mod tests {
 
 	#[test]
 	fn test_oso_crate_equality_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate1 = OsoCrate::from(current_dir.clone(),);
 		let crate2 = OsoCrate::from(current_dir.clone(),);
 
@@ -329,7 +348,8 @@ mod tests {
 
 	#[test]
 	fn test_crate_info_path_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 
 		// Test CrateInfo::path method
@@ -338,7 +358,8 @@ mod tests {
 
 	#[test]
 	fn test_crate_called_whoami_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 
 		// Test CrateCalled::whoami method
@@ -348,7 +369,8 @@ mod tests {
 
 	#[test]
 	fn test_crate_called_path_buf_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 
 		// Test CrateCalled::path_buf method
@@ -357,7 +379,8 @@ mod tests {
 
 	#[test]
 	fn test_from_pathbuf_conversion_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 
 		// Test From<PathBuf> implementation
 		let crate_obj: OsoCrate = current_dir.clone().into();
@@ -373,7 +396,8 @@ mod tests {
 
 	#[test]
 	fn test_oso_crate_chart_conversion_with_current_dir() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 
 		// Test that we can get the chart representation
@@ -389,7 +413,8 @@ mod tests {
 
 	#[test]
 	fn test_debug_implementation() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that Debug is implemented
@@ -402,12 +427,14 @@ mod tests {
 
 	#[test]
 	fn test_crate_action_methods_exist() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
-		// Test that action methods exist (they will likely fail in test environment)
-		// ignore `test` method because running it in test cause infinity loop
-		// ignore `run` too because this crate is library crate. nothing to run.
+		// Test that action methods exist (they will likely fail in test
+		// environment) ignore `test` method because running it in test cause
+		// infinity loop ignore `run` too because this crate is library crate.
+		// nothing to run.
 		let _build_result = crate_obj.build();
 		let _check_result = crate_obj.check();
 		let _fmt_result = crate_obj.format();
@@ -417,12 +444,14 @@ mod tests {
 
 	#[test]
 	fn test_crate_action_with_methods_exist() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that action methods with options exist
-		// ignore `test_with` method because running it in test cause infinity loop
-		// ignore `run_with` too because this crate is library crate. nothing to run.
+		// ignore `test_with` method because running it in test cause infinity
+		// loop ignore `run_with` too because this crate is library crate.
+		// nothing to run.
 		let opts = ["--release",];
 		let _build_result = crate_obj.build_with(&opts,);
 		let _check_result = crate_obj.ckeck_with(&opts,);
@@ -431,7 +460,8 @@ mod tests {
 
 	#[test]
 	fn test_crate_info_methods() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that CrateInfo methods exist and return Results
@@ -444,7 +474,8 @@ mod tests {
 
 	#[test]
 	fn test_package_survey_methods() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test PackageSurvey methods
@@ -464,7 +495,8 @@ mod tests {
 
 	#[test]
 	fn test_workspace_info_methods() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test WorkspaceInfo methods
@@ -475,8 +507,10 @@ mod tests {
 
 	#[test]
 	fn test_workspace_survey_land_on() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let mut crate_obj = OsoCrate::from(current_dir,);
 		let target_crate = OsoCrate::from(parent_dir.clone(),);
@@ -490,11 +524,13 @@ mod tests {
 
 	#[test]
 	fn test_trait_implementations() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that all required traits are implemented
-		// These are compile-time checks using concrete types since traits are not object-safe
+		// These are compile-time checks using concrete types since traits are
+		// not object-safe
 
 		// Test that we can use the crate as different trait implementors
 		let _crate_ref: &OsoCrate = &crate_obj;
@@ -507,11 +543,13 @@ mod tests {
 	// Test the survey methods that contain todo!() - they should panic
 	#[test]
 	fn test_crate_survey_todo_methods() {
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that survey methods exist (they contain todo!() so will panic)
-		let has_parent_result = std::panic::catch_unwind(|| crate_obj.has_parent(),);
+		let has_parent_result =
+			std::panic::catch_unwind(|| crate_obj.has_parent(),);
 		let go_parent_result = std::panic::catch_unwind(|| {
 			let mut obj = crate_obj.clone();
 			obj.go_parent()

--- a/oso_dev_util/src/decl_manage/package.rs
+++ b/oso_dev_util/src/decl_manage/package.rs
@@ -28,15 +28,18 @@ mod tests {
 	use crate::decl_manage::crate_::OsoCrate;
 	use std::path::PathBuf;
 
-	// Note: Working around FromPathBuf macro validation by using current directory
+	// Note: Working around FromPathBuf macro validation by using current
+	// directory
 
 	#[test]
 	fn test_package_trait_hierarchy() {
 		// Test that Package trait requires both PackageAction and PackageSurvey
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
-		// Test that OsoCrate implements Package (using concrete type since not object-safe)
+		// Test that OsoCrate implements Package (using concrete type since not
+		// object-safe)
 		let _package_ref: &OsoCrate = &crate_obj;
 
 		// Test as_action method
@@ -49,7 +52,8 @@ mod tests {
 	#[test]
 	fn test_package_action_trait() {
 		// Test that PackageAction combines PackageInfo and CrateAction
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that OsoCrate implements PackageAction (concrete type only)
@@ -61,7 +65,11 @@ mod tests {
 		let check_result = crate_obj.check();
 
 		// If we get here without compilation errors, PackageAction is working
-		assert!(build_result.is_ok() || format_result.is_ok() || check_result.is_ok());
+		assert!(
+			build_result.is_ok()
+				|| format_result.is_ok()
+				|| check_result.is_ok()
+		);
 	}
 
 	#[test]
@@ -71,7 +79,8 @@ mod tests {
 		use crate::cargo::Feature;
 		use crate::cargo::Opts;
 
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test that OsoCrate implements PackageSurvey
@@ -85,7 +94,8 @@ mod tests {
 	#[test]
 	fn test_package_info_trait() {
 		// Test that PackageInfo extends CrateInfo
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir.clone(),);
 
 		// Test that OsoCrate implements PackageInfo (concrete type only)
@@ -120,7 +130,8 @@ mod tests {
 			let _path = info.path();
 		}
 
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		test_package(&crate_obj,);
@@ -139,7 +150,8 @@ mod tests {
 			let _survey = package.as_survey();
 		}
 
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		work_with_package(crate_obj,);

--- a/oso_dev_util/src/decl_manage/workspace.rs
+++ b/oso_dev_util/src/decl_manage/workspace.rs
@@ -39,31 +39,67 @@ pub trait WorkspaceAction: WorkspaceInfo + CrateAction {
 	where Self: WorkspaceSurvey {
 		self.cargo_xxx_at("fmt", at,)
 	}
-	fn cargo_xxx_at(&self, cmd: impl AsRef<OsStr,>, at: impl CrateCalled,) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn cargo_xxx_at(
+		&self,
+		cmd: impl AsRef<OsStr,>,
+		at: impl CrateCalled,
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with(cmd, at, &["",],)
 	}
 
 	// actions for specific package with specific options
 
-	fn build_at_with(&self, at: impl CrateCalled, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn build_at_with(
+		&self,
+		at: impl CrateCalled,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with("build", at, opt,)
 	}
-	fn test_at_with(&self, at: impl CrateCalled, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn test_at_with(
+		&self,
+		at: impl CrateCalled,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with("test", at, opt,)
 	}
-	fn run_at_with(&self, at: impl CrateCalled, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn run_at_with(
+		&self,
+		at: impl CrateCalled,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with("run", at, opt,)
 	}
-	fn check_at_with(&self, at: impl CrateCalled, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn check_at_with(
+		&self,
+		at: impl CrateCalled,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with("check", at, opt,)
 	}
-	fn fmt_at_with(&self, at: impl CrateCalled, opt: &[impl AsRef<OsStr,>],) -> Rslt<(),>
-	where Self: WorkspaceSurvey {
+	fn fmt_at_with(
+		&self,
+		at: impl CrateCalled,
+		opt: &[impl AsRef<OsStr,>],
+	) -> Rslt<(),>
+	where
+		Self: WorkspaceSurvey,
+	{
 		self.cargo_xxx_at_with("fmt", at, opt,)
 	}
 	fn cargo_xxx_at_with(
@@ -77,7 +113,8 @@ pub trait WorkspaceAction: WorkspaceInfo + CrateAction {
 	{
 		let current = self.whoami();
 		//  this operation is safe due to `&self` is valid
-		let self_mut = unsafe { (self as *const Self).cast_mut().as_mut().unwrap() };
+		let self_mut =
+			unsafe { (self as *const Self).cast_mut().as_mut().unwrap() };
 		self_mut.land_on(at,);
 		self_mut.cargo_xxx_with(cmd, opt,)?;
 		self_mut.land_on(current,);
@@ -89,9 +126,10 @@ pub trait WorkspaceSurvey: WorkspaceInfo + CrateSurvey {}
 
 /// Trait for managing OSO workspace operations
 ///
-/// This trait provides an interface for workspace management operations including
-/// root directory access and crate enumeration. It's designed to work with
-/// multi-crate Rust workspaces and provides a consistent API for workspace operations.
+/// This trait provides an interface for workspace management operations
+/// including root directory access and crate enumeration. It's designed to work
+/// with multi-crate Rust workspaces and provides a consistent API for workspace
+/// operations.
 ///
 /// # Type Parameters
 ///
@@ -130,7 +168,10 @@ pub trait WorkspaceInfo: Sized + CrateInfo {
 	/// ```
 	fn members(&self,) -> Vec<impl Crate,>;
 
-	fn members_with_target(&self, target: impl Into<String,> + Clone,) -> Vec<impl Crate,>;
+	fn members_with_target(
+		&self,
+		target: impl Into<String,> + Clone,
+	) -> Vec<impl Crate,>;
 }
 
 #[cfg(test)]
@@ -143,16 +184,19 @@ mod tests {
 	#[test]
 	fn test_workspace_action_at_methods() {
 		// Test workspace action methods that operate on specific crates
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let workspace = OsoCrate::from(current_dir,);
 		let target_crate = OsoCrate::from(parent_dir,);
 
 		// Test action methods (they will likely fail in test environment)
-		// Note: These methods require WorkspaceSurvey bound, which OsoCrate implements
-		// ignore `test_at` method because running it in test cause infinity loop
-		// ignore `run_at` too because this crate is library crate. nothing to run.
+		// Note: These methods require WorkspaceSurvey bound, which OsoCrate
+		// implements ignore `test_at` method because running it in test cause
+		// infinity loop ignore `run_at` too because this crate is library
+		// crate. nothing to run.
 		let _build_result = workspace.build_at(target_crate.clone(),);
 		let _check_result = workspace.check_at(target_crate.clone(),);
 		let _fmt_result = workspace.fmt_at(target_crate,);
@@ -163,8 +207,10 @@ mod tests {
 	#[test]
 	fn test_workspace_action_at_with_methods() {
 		// Test workspace action methods with options
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let workspace = OsoCrate::from(current_dir,);
 		let target_crate = OsoCrate::from(parent_dir,);
@@ -172,10 +218,13 @@ mod tests {
 		let opts = ["--verbose",];
 
 		// Test action methods with options
-		// ignore `test_at_with` method because running it in test cause infinity loop
-		// ignore `run_at_with` too because this crate is library crate. nothing to run.
-		let _build_result = workspace.build_at_with(target_crate.clone(), &opts,);
-		let _check_result = workspace.check_at_with(target_crate.clone(), &opts,);
+		// ignore `test_at_with` method because running it in test cause
+		// infinity loop ignore `run_at_with` too because this crate is
+		// library crate. nothing to run.
+		let _build_result =
+			workspace.build_at_with(target_crate.clone(), &opts,);
+		let _check_result =
+			workspace.check_at_with(target_crate.clone(), &opts,);
 		let _fmt_result = workspace.fmt_at_with(target_crate, &["--all",],);
 
 		// If we get here without compilation errors, the methods exist
@@ -184,8 +233,10 @@ mod tests {
 	#[test]
 	fn test_workspace_action_cargo_xxx_at() {
 		// Test the generic cargo_xxx_at method
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let workspace = OsoCrate::from(current_dir,);
 		let target_crate = OsoCrate::from(parent_dir,);
@@ -199,8 +250,10 @@ mod tests {
 	#[test]
 	fn test_workspace_action_cargo_xxx_at_with() {
 		// Test the generic cargo_xxx_at_with method
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let workspace = OsoCrate::from(current_dir,);
 		let target_crate = OsoCrate::from(parent_dir,);
@@ -208,7 +261,8 @@ mod tests {
 		let opts = ["--all-targets",];
 
 		// Test generic cargo command with options
-		let _result = workspace.cargo_xxx_at_with("clippy", target_crate, &opts,);
+		let _result =
+			workspace.cargo_xxx_at_with("clippy", target_crate, &opts,);
 
 		// If we get here without compilation errors, the method exists
 	}
@@ -216,7 +270,8 @@ mod tests {
 	#[test]
 	fn test_workspace_trait_as_methods() {
 		// Test the as_action and as_survey methods
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test as_action returns something implementing WorkspaceAction
@@ -231,7 +286,8 @@ mod tests {
 	#[test]
 	fn test_workspace_info_members_signature() {
 		// Test that members method has the correct signature
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test the method signature
@@ -239,14 +295,16 @@ mod tests {
 
 		// Should return a Vec of items implementing Crate
 		for _member in members {
-			// Can't use trait objects due to object safety, but we can verify the type
+			// Can't use trait objects due to object safety, but we can verify
+			// the type
 		}
 	}
 
 	#[test]
 	fn test_workspace_info_members_with_target_signature() {
 		// Test that members_with_target method has the correct signature
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		// Test with string literal
@@ -258,15 +316,18 @@ mod tests {
 
 		// Both should return Vec of Crate implementors
 		for _member in members1.into_iter().chain(members2,) {
-			// Can't use trait objects due to object safety, but we can verify the type
+			// Can't use trait objects due to object safety, but we can verify
+			// the type
 		}
 	}
 
 	#[test]
 	fn test_workspace_survey_land_on_signature() {
 		// Test that land_on method has the correct signature
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let mut workspace = OsoCrate::from(current_dir,);
 		let target = OsoCrate::from(parent_dir.clone(),);
@@ -299,7 +360,8 @@ mod tests {
 			let _members = info.members();
 		}
 
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		test_workspace(&crate_obj,);
@@ -311,18 +373,22 @@ mod tests {
 	#[test]
 	fn test_workspace_integration() {
 		// Test that Workspace trait integrates all functionality
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
-		let parent_dir = current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let parent_dir =
+			current_dir.parent().unwrap_or(&current_dir,).to_path_buf();
 
 		let workspace = OsoCrate::from(current_dir.clone(),);
 		let target = OsoCrate::from(parent_dir,);
 
-		// Test Workspace functionality directly (not as trait object since not object-safe)
+		// Test Workspace functionality directly (not as trait object since not
+		// object-safe)
 
 		// Should have access to action methods through as_action
 		let action = workspace.as_action();
 		let _build_result = action.build();
-		// Note: build_at requires WorkspaceSurvey bound, test it directly on workspace
+		// Note: build_at requires WorkspaceSurvey bound, test it directly on
+		// workspace
 		let _build_at_result = workspace.build_at(target.clone(),);
 
 		// Should have access to survey methods through as_survey
@@ -344,7 +410,8 @@ mod tests {
 			let _survey = workspace.as_survey();
 		}
 
-		let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
+		let current_dir =
+			std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".",),);
 		let crate_obj = OsoCrate::from(current_dir,);
 
 		work_with_workspace(crate_obj,);

--- a/oso_dev_util/src/fs.rs
+++ b/oso_dev_util/src/fs.rs
@@ -121,8 +121,8 @@ mod tests {
 	#[test]
 	fn test_function_error_propagation() {
 		// Test that errors from helper functions are properly propagated
-		// This is a behavioral test - we can't easily mock the helper functions,
-		// but we can verify the error handling structure
+		// This is a behavioral test - we can't easily mock the helper
+		// functions, but we can verify the error handling structure
 
 		// Test project_root error handling
 		let project_result = project_root();
@@ -257,7 +257,8 @@ mod tests {
 				assert!(true);
 			},
 			_ => {
-				// Mixed success/failure might be valid depending on implementation
+				// Mixed success/failure might be valid depending on
+				// implementation
 				assert!(true);
 			},
 		}
@@ -273,7 +274,8 @@ mod tests {
 				assert!(true);
 			},
 			_ => {
-				// Mixed success/failure might be valid depending on implementation
+				// Mixed success/failure might be valid depending on
+				// implementation
 				assert!(true);
 			},
 		}
@@ -319,8 +321,8 @@ mod tests {
 			let path = project_crate.path();
 
 			// Path should be valid for filesystem operations
-			// Note: We can't guarantee the path exists in all test environments,
-			// but we can test that it's a valid path structure
+			// Note: We can't guarantee the path exists in all test
+			// environments, but we can test that it's a valid path structure
 			assert!(!path.as_os_str().is_empty());
 
 			// Test that path can be converted to string
@@ -387,7 +389,8 @@ mod tests {
 				thread::spawn(|| {
 					let _project_result = project_root();
 					let _current_result = current_crate();
-					// If we get here without panicking, the functions are thread-safe
+					// If we get here without panicking, the functions are
+					// thread-safe
 					true
 				},)
 			},)

--- a/oso_dev_util/src/lib.rs
+++ b/oso_dev_util/src/lib.rs
@@ -1,14 +1,14 @@
 //! # OSO Development Utilities
 //!
-//! A collection of development utilities and helper functions for the OSO operating system project.
-//! This crate provides tools for workspace management, command execution, and development workflow
-//! automation.
+//! A collection of development utilities and helper functions for the OSO
+//! operating system project. This crate provides tools for workspace
+//! management, command execution, and development workflow automation.
 //!
 //! ## Features
 //!
 //! - **Workspace Management**: Tools for managing multi-crate workspaces
-//! - **Command Execution**: Enhanced command execution with better error handling and output
-//!   formatting
+//! - **Command Execution**: Enhanced command execution with better error
+//!   handling and output formatting
 //! - **Development Workflow**: Utilities to streamline the development process
 //! - **Cross-platform Support**: Works across different operating systems
 //!
@@ -98,21 +98,26 @@ mod tests {
 
 		// Verify the path exists
 		let path = std::path::Path::new(OSO_DEV_UTIL_PATH,);
-		assert!(path.exists(), "OSO_DEV_UTIL_PATH should point to an existing file");
+		assert!(
+			path.exists(),
+			"OSO_DEV_UTIL_PATH should point to an existing file"
+		);
 		assert!(path.is_file(), "OSO_DEV_UTIL_PATH should point to a file");
 	}
 
 	#[test]
 	fn test_module_accessibility() {
 		// Test that all public modules are accessible
-		// This is a compile-time test - if it compiles, the modules are accessible
+		// This is a compile-time test - if it compiles, the modules are
+		// accessible
 
 		// Test cargo module
 		let _build_mode = cargo::BuildMode::Debug;
 		let _arch = cargo::Arch::Aarch64;
 
 		// Test that we can access the fs module functions
-		// Note: These might fail in test environment, but we test they're callable
+		// Note: These might fail in test environment, but we test they're
+		// callable
 		let _project_root_result = fs::project_root();
 		let _current_crate_result = fs::current_crate();
 	}
@@ -128,7 +133,8 @@ mod tests {
 		assert!(result.is_err());
 		let error_string = result.unwrap_err().to_string();
 		assert!(error_string.contains("additional context"));
-		// Note: The exact error message format may vary, so we just check for context
+		// Note: The exact error message format may vary, so we just check for
+		// context
 	}
 
 	#[test]
@@ -235,7 +241,11 @@ mod tests {
 		// Test CLI with default values
 		use cargo::Cli;
 
-		let cli = Cli { build_mode: None, feature_flags: None, arch: None, };
+		let cli = Cli {
+			build_mode:    None,
+			feature_flags: None,
+			arch:          None,
+		};
 
 		let opts = cli.to_opts();
 		assert!(opts.build_mode.is_debug()); // Default should be Debug
@@ -371,7 +381,8 @@ mod tests {
 		assert_eq!(path.file_name().unwrap(), "Cargo.toml");
 
 		// Should be readable
-		let content = std::fs::read_to_string(path,).expect("Should be able to read Cargo.toml",);
+		let content = std::fs::read_to_string(path,)
+			.expect("Should be able to read Cargo.toml",);
 		assert!(content.contains("[package]"));
 		assert!(content.contains("oso_dev_util"));
 	}
@@ -482,7 +493,11 @@ mod tests {
 
 		for &build_mode in &all_build_modes {
 			for &arch in &all_archs {
-				let opts = Opts { build_mode, feature_flags: Vec::<Feature,>::new(), arch, };
+				let opts = Opts {
+					build_mode,
+					feature_flags: Vec::<Feature,>::new(),
+					arch,
+				};
 
 				// Test CompileOpt trait methods
 				let _build_mode_str: String = opts.build_mode().into();
@@ -504,7 +519,8 @@ mod tests {
 		assert!(manifest_path.is_file());
 
 		// Test path operations
-		let parent = manifest_path.parent().expect("Should have parent directory",);
+		let parent =
+			manifest_path.parent().expect("Should have parent directory",);
 		assert!(parent.exists());
 		assert!(parent.is_dir());
 
@@ -556,9 +572,17 @@ mod tests {
 		let mut opts_vec = Vec::new();
 		for i in 0..1000 {
 			let opts = Opts {
-				build_mode:    if i % 2 == 0 { BuildMode::Debug } else { BuildMode::Release },
+				build_mode:    if i % 2 == 0 {
+					BuildMode::Debug
+				} else {
+					BuildMode::Release
+				},
 				feature_flags: Vec::<Feature,>::new(),
-				arch:          if i % 2 == 0 { Arch::Aarch64 } else { Arch::Riscv64 },
+				arch:          if i % 2 == 0 {
+					Arch::Aarch64
+				} else {
+					Arch::Riscv64
+				},
 			};
 			opts_vec.push(opts,);
 		}


### PR DESCRIPTION
Purpose
- refactor(oso_dev_util): streamline decl and fs utilities

Details
- Branch groups        7 file(s) related to refactor/oso-dev-util
- See commit for rationale and scope

Included paths (sample)
- oso_dev_util/src/cargo.rs
- oso_dev_util/src/decl_manage.rs
- oso_dev_util/src/decl_manage/crate_.rs
- oso_dev_util/src/decl_manage/package.rs
- oso_dev_util/src/decl_manage/workspace.rs
- oso_dev_util/src/fs.rs
- oso_dev_util/src/lib.rs