### PR TITLE
refactor(oso_loader): reorganize UEFI and ELF loading modules

### DIFF
--- a/oso_loader/src/chibi_uefi.rs
+++ b/oso_loader/src/chibi_uefi.rs
@@ -1,8 +1,9 @@
 //! # Chibi UEFI - Lightweight UEFI Interface Wrapper
 //!
-//! This module provides a simplified, lightweight wrapper around UEFI (Unified Extensible
-//! Firmware Interface) services and protocols. It abstracts the complexity of raw UEFI
-//! operations while maintaining safety and efficiency for bootloader operations.
+//! This module provides a simplified, lightweight wrapper around UEFI (Unified
+//! Extensible Firmware Interface) services and protocols. It abstracts the
+//! complexity of raw UEFI operations while maintaining safety and efficiency
+//! for bootloader operations.
 //!
 //! ## Features
 //!
@@ -62,10 +63,11 @@ pub mod table;
 
 /// Global storage for the UEFI image handle
 ///
-/// This atomic pointer stores the image handle for the current UEFI application,
-/// allowing access to it from anywhere in the codebase. It's set during
-/// initialization and used throughout the bootloader's lifetime.
-static IMAGE_HANDLE: AtomicPtr<c_void,> = AtomicPtr::new(core::ptr::null_mut(),);
+/// This atomic pointer stores the image handle for the current UEFI
+/// application, allowing access to it from anywhere in the codebase. It's set
+/// during initialization and used throughout the bootloader's lifetime.
+static IMAGE_HANDLE: AtomicPtr<c_void,> =
+	AtomicPtr::new(core::ptr::null_mut(),);
 
 /// Type-safe wrapper around UEFI handles
 ///
@@ -169,8 +171,10 @@ impl BootServices {
 	pub fn exit_boot_services(&self,) {
 		let mem_ty = MemoryType::BOOT_SERVICES_DATA;
 
-		let mut buf = MemoryMapBackingMemory::new(mem_ty,).expect("failed to allocate memory",);
-		let status = unsafe { self.try_exit_boot_services(buf.as_mut_slice(),) };
+		let mut buf = MemoryMapBackingMemory::new(mem_ty,)
+			.expect("failed to allocate memory",);
+		let status =
+			unsafe { self.try_exit_boot_services(buf.as_mut_slice(),) };
 
 		if !status.is_success() {
 			todo!("failed to exit boot service. reset the machine");
@@ -180,7 +184,9 @@ impl BootServices {
 	unsafe fn try_exit_boot_services(&self, buf: &mut [u8],) -> Status {
 		let mem_map = self.get_memory_map(buf,).expect("failed to get memmap",);
 		// core::mem::forget(mem_map,);
-		unsafe { (self.exit_boot_services)(image_handle().as_ptr(), mem_map.map_key,) }
+		unsafe {
+			(self.exit_boot_services)(image_handle().as_ptr(), mem_map.map_key,)
+		}
 	}
 }
 
@@ -199,7 +205,12 @@ impl RuntimeServices {
 	/// # Note
 	///
 	/// This function never returns as it resets the system.
-	pub fn reset(&self, _reset_type: ResetType, _status: Status, _data: Option<&[u8],>,) -> ! {
+	pub fn reset(
+		&self,
+		_reset_type: ResetType,
+		_status: Status,
+		_data: Option<&[u8],>,
+	) -> ! {
 		todo!()
 	}
 }
@@ -216,10 +227,13 @@ impl RuntimeServices {
 ///
 /// # Panics
 ///
-/// Panics if `set_image_handle_panicking` has not been called to initialize the handle.
+/// Panics if `set_image_handle_panicking` has not been called to initialize the
+/// handle.
 pub fn image_handle() -> Handle {
 	let p = IMAGE_HANDLE.load(Ordering::Acquire,);
-	unsafe { Handle::from_ptr(p,).expect("set_image_handle has not been called",) }
+	unsafe {
+		Handle::from_ptr(p,).expect("set_image_handle has not been called",)
+	}
 }
 /// Sets the global image handle (unsafe version)
 ///
@@ -237,8 +251,9 @@ unsafe fn set_image_handle(image_handle: Handle,) {
 
 /// Sets the global image handle (panicking version)
 ///
-/// This function sets the global image handle for use throughout the application.
-/// It's typically called during initialization with the handle provided by UEFI.
+/// This function sets the global image handle for use throughout the
+/// application. It's typically called during initialization with the handle
+/// provided by UEFI.
 ///
 /// # Arguments
 ///

--- a/oso_loader/src/chibi_uefi/guid.rs
+++ b/oso_loader/src/chibi_uefi/guid.rs
@@ -13,7 +13,11 @@ macro_rules! guid {
 impl Guid {
 	#[track_caller]
 	pub fn gen_from_str(s: impl AsRef<str,>,) -> Rslt<Self,> {
-		let mut s = s.as_ref().chars().filter_map(|c| Hex::try_from(c,).ok(),).map(|h| h as u8,);
+		let mut s = s
+			.as_ref()
+			.chars()
+			.filter_map(|c| Hex::try_from(c,).ok(),)
+			.map(|h| h as u8,);
 		let mut time_low: [u8; 4] = s.next_chunk().unwrap();
 		time_low.reverse();
 		let mut time_mid: [u8; 2] = s.next_chunk().unwrap();
@@ -47,7 +51,8 @@ impl Guid {
 		let time_high_and_version: [u8; 2] = [hex[7], hex[6],];
 		let clock_seq_high_and_reserved = hex[8];
 		let clock_seq_low = hex[9];
-		let node: [u8; 6] = [hex[10], hex[11], hex[12], hex[13], hex[14], hex[15],];
+		let node: [u8; 6] =
+			[hex[10], hex[11], hex[12], hex[13], hex[14], hex[15],];
 		Guid::new(
 			time_low,
 			time_mid,
@@ -161,13 +166,19 @@ pub trait BytesToInt<const N: usize,> {
 }
 
 pub trait BytesNotTooLong<const B: bool,> {}
-impl<const BYTES: usize,> BytesNotTooLong<{ bytes_not_too_long::<BYTES,>() },> for [Hex; BYTES] {}
+impl<const BYTES: usize,> BytesNotTooLong<{ bytes_not_too_long::<BYTES,>() },>
+	for [Hex; BYTES]
+{
+}
 const fn bytes_not_too_long<const BYTES: usize,>() -> bool {
 	BYTES <= 32
 }
 
 pub trait BytesIsEven<const B: bool, const N: usize,> {}
-impl<const BYTES: usize,> BytesIsEven<{ bytes_is_even::<BYTES,>() }, BYTES,> for [Hex; BYTES] {}
+impl<const BYTES: usize,> BytesIsEven<{ bytes_is_even::<BYTES,>() }, BYTES,>
+	for [Hex; BYTES]
+{
+}
 const fn bytes_is_even<const BYTES: usize,>() -> bool {
 	BYTES.is_multiple_of(2,)
 }
@@ -193,7 +204,8 @@ pub trait AsBytes<const BYTES: usize, O = Self,> {
 	fn as_bytes(&self,) -> Self::Output;
 }
 
-impl<const BYTES: usize,> const AsBytes<BYTES, [u8; BYTES / 2],> for [Hex; BYTES]
+impl<const BYTES: usize,> const AsBytes<BYTES, [u8; BYTES / 2],>
+	for [Hex; BYTES]
 where [Hex; BYTES]: BytesNotTooLong<true,> + BytesIsEven<true, BYTES,>
 {
 	fn as_bytes(&self,) -> Self::Output {

--- a/oso_loader/src/chibi_uefi/memory.rs
+++ b/oso_loader/src/chibi_uefi/memory.rs
@@ -27,7 +27,9 @@ unsafe impl GlobalAlloc for LoaderAllocator {
 		}
 		let mem_ty = MemoryType::LOADER_DATA;
 		let bs = boot_services();
-		bs.allocate_pool(mem_ty, layout.size(),).expect("allocation failed",).as_ptr()
+		bs.allocate_pool(mem_ty, layout.size(),)
+			.expect("allocation failed",)
+			.as_ptr()
 	}
 
 	unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout,) {
@@ -35,7 +37,8 @@ unsafe impl GlobalAlloc for LoaderAllocator {
 			panic!()
 		}
 		let bs = boot_services();
-		bs.free_pool(unsafe { ptr.as_mut_unchecked() },).expect("deallocation failed",);
+		bs.free_pool(unsafe { ptr.as_mut_unchecked() },)
+			.expect("deallocation failed",);
 	}
 }
 
@@ -45,7 +48,11 @@ fn alloc_error(layout: Layout,) -> ! {
 }
 
 impl BootServices {
-	pub fn allocate_pool(&self, mem_ty: MemoryType, size: usize,) -> RsltU<NonNull<u8,>,> {
+	pub fn allocate_pool(
+		&self,
+		mem_ty: MemoryType,
+		size: usize,
+	) -> RsltU<NonNull<u8,>,> {
 		let mut buf = core::ptr::null_mut();
 		unsafe { (self.allocate_pool)(mem_ty, size, &mut buf,) }.ok_or()?;
 		Ok(unsafe {
@@ -65,8 +72,15 @@ impl BootServices {
 		page_count: usize,
 		mut alloc_head: PhysicalAddress,
 	) -> RsltU<PhysicalAddress,> {
-		unsafe { (self.allocate_pages)(allocation_type, mem_ty, page_count, &mut alloc_head,) }
-			.ok_or_with(|_| alloc_head,)
+		unsafe {
+			(self.allocate_pages)(
+				allocation_type,
+				mem_ty,
+				page_count,
+				&mut alloc_head,
+			)
+		}
+		.ok_or_with(|_| alloc_head,)
 	}
 
 	pub fn memory_map_size(&self,) -> (usize, usize,) {
@@ -86,12 +100,18 @@ impl BootServices {
 		};
 		assert_eq!(status, Status::EFI_BUFFER_TOO_SMALL);
 
-		assert_eq!(map_size % descriptor_size, 0, "memory map size is multiple of descriptor size");
+		assert_eq!(
+			map_size % descriptor_size,
+			0,
+			"memory map size is multiple of descriptor size"
+		);
 
-		let memory_map_info =
-			MemoryMapInfo {
-				map_size, desc_size: descriptor_size, map_key, desc_ver: desc_version,
-			};
+		let memory_map_info = MemoryMapInfo {
+			map_size,
+			desc_size: descriptor_size,
+			map_key,
+			desc_ver: desc_version,
+		};
 
 		memory_map_info.assert_sanity_check();
 
@@ -120,6 +140,11 @@ impl BootServices {
 				&mut desc_ver,
 			)
 		}
-		.ok_or_with(|_| MemoryMapInfo { map_size, desc_size, map_key, desc_ver, },)
+		.ok_or_with(|_| MemoryMapInfo {
+			map_size,
+			desc_size,
+			map_key,
+			desc_ver,
+		},)
 	}
 }

--- a/oso_loader/src/chibi_uefi/table.rs
+++ b/oso_loader/src/chibi_uefi/table.rs
@@ -5,7 +5,8 @@ use core::ptr::NonNull;
 use core::sync::atomic::AtomicPtr;
 use core::sync::atomic::Ordering;
 
-static SYSTEM_TABLE: AtomicPtr<SystemTable,> = AtomicPtr::new(core::ptr::null_mut(),);
+static SYSTEM_TABLE: AtomicPtr<SystemTable,> =
+	AtomicPtr::new(core::ptr::null_mut(),);
 
 unsafe fn set_system_table(ptr: *const SystemTable,) {
 	SYSTEM_TABLE.store(ptr.cast_mut(), Ordering::Release,);

--- a/oso_loader/src/elf/hash.rs
+++ b/oso_loader/src/elf/hash.rs
@@ -11,9 +11,12 @@ pub fn gnu_hash_len(
 	mut offset: usize,
 	context: &Context,
 ) -> Rslt<usize, EfiParseError,> {
-	let buckets_count = read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
-	let min_chain = read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
-	let bloom_size = read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
+	let buckets_count =
+		read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
+	let min_chain =
+		read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
+	let bloom_size =
+		read_le_bytes::<u32,>(&mut offset, binary,).unwrap() as usize;
 	if buckets_count == 0 || min_chain == 0 || bloom_size == 0 {
 		return Err(oso_err!(EfiParseError::InvalidGnuHash {
 			buckets_count,
@@ -23,12 +26,14 @@ pub fn gnu_hash_len(
 	}
 
 	// find the last bucket
-	let buckets_offset =
-		offset + 4 + bloom_size * if context.container == Container::Big { 8 } else { 4 };
+	let buckets_offset = offset
+		+ 4 + bloom_size
+		* if context.container == Container::Big { 8 } else { 4 };
 	let mut max_chain = 0;
 	for bucket in 0..buckets_count {
 		let chain =
-			read_le_bytes::<u32,>(&mut (buckets_offset + bucket * 4), binary,).unwrap() as usize;
+			read_le_bytes::<u32,>(&mut (buckets_offset + bucket * 4), binary,)
+				.unwrap() as usize;
 		if max_chain < chain {
 			max_chain = chain;
 		}
@@ -39,9 +44,11 @@ pub fn gnu_hash_len(
 	}
 
 	// find the last chain within the bucket
-	let mut chain_offset = buckets_offset + buckets_count * 4 + (max_chain - min_chain) * 4;
+	let mut chain_offset =
+		buckets_offset + buckets_count * 4 + (max_chain - min_chain) * 4;
 	loop {
-		let hash = read_le_bytes::<u32,>(&mut chain_offset, binary,).unwrap() as usize;
+		let hash =
+			read_le_bytes::<u32,>(&mut chain_offset, binary,).unwrap() as usize;
 		max_chain += 1;
 		if hash & 1 != 0 {
 			return Ok(max_chain,);
@@ -56,7 +63,8 @@ pub fn hash_len(
 	context: &Context,
 ) -> Rslt<usize, EfiParseError,> {
 	offset = offset.saturating_add(4,);
-	let nchain = if (machine == ElfHeader::EM_FAKE_ALPHA || machine == ElfHeader::EM_S390)
+	let nchain = if (machine == ElfHeader::EM_FAKE_ALPHA
+		|| machine == ElfHeader::EM_S390)
 		&& context.container == Container::Big
 	{
 		read_le_bytes::<u64,>(&mut offset, binary,).unwrap() as usize

--- a/oso_loader/src/elf/program_header.rs
+++ b/oso_loader/src/elf/program_header.rs
@@ -149,7 +149,9 @@ impl TryFrom<u32,> for ProgramHeaderType {
 			0x6fff_fffb => Self::Sunwstack,
 			7 => Self::Tls,
 			_ => {
-				return Err(oso_err!(EfiParseError::InvalidProgramHeaderType(value)),);
+				return Err(oso_err!(EfiParseError::InvalidProgramHeaderType(
+					value
+				)),);
 			},
 		};
 		Ok(ty,)

--- a/oso_loader/src/elf/section_header.rs
+++ b/oso_loader/src/elf/section_header.rs
@@ -139,7 +139,10 @@ impl SectionHeader {
 		Ok(section_headers,)
 	}
 
-	fn parse_fields(binary: &[u8], offset: &mut usize,) -> Rslt<Self, EfiParseError,> {
+	fn parse_fields(
+		binary: &[u8],
+		offset: &mut usize,
+	) -> Rslt<Self, EfiParseError,> {
 		macro_rules! fields {
 			($field:ident) => {
 				let Some($field,) = read_le_bytes(offset, binary,) else {

--- a/oso_loader/src/lib.rs
+++ b/oso_loader/src/lib.rs
@@ -1,15 +1,19 @@
 //! # OSO Loader
 //!
-//! A UEFI-based bootloader for the OSO operating system that handles ELF kernel loading
-//! and system initialization across multiple architectures (x86_64, aarch64, riscv64).
+//! A UEFI-based bootloader for the OSO operating system that handles ELF kernel
+//! loading and system initialization across multiple architectures (x86_64,
+//! aarch64, riscv64).
 //!
 //! ## Features
 //!
 //! - **ELF Kernel Loading**: Parses and loads ELF format kernels into memory
-//! - **Multi-architecture Support**: Supports x86_64, aarch64, and riscv64 architectures
+//! - **Multi-architecture Support**: Supports x86_64, aarch64, and riscv64
+//!   architectures
 //! - **UEFI Integration**: Provides a lightweight UEFI interface wrapper
-//! - **Device Tree Support**: Handles device tree configuration for kernel handoff
-//! - **Graphics Configuration**: Sets up frame buffer configuration for kernel graphics
+//! - **Device Tree Support**: Handles device tree configuration for kernel
+//!   handoff
+//! - **Graphics Configuration**: Sets up frame buffer configuration for kernel
+//!   graphics
 //! - **Memory Management**: Manages memory allocation and MMU configuration
 //!
 //! ## Architecture-specific Features
@@ -21,8 +25,9 @@
 //!
 //! ## Usage
 //!
-//! This crate is designed to be compiled as a UEFI application. The main entry point
-//! is `efi_main` which initializes the system, loads the kernel, and transfers control.
+//! This crate is designed to be compiled as a UEFI application. The main entry
+//! point is `efi_main` which initializes the system, loads the kernel, and
+//! transfers control.
 
 #![no_std]
 #![allow(incomplete_features)]
@@ -67,7 +72,8 @@ pub mod raw;
 /// Custom panic handler for the UEFI environment
 ///
 /// This panic handler prints debug information and enters a wait-for-event loop
-/// instead of terminating the program, which is appropriate for a UEFI application.
+/// instead of terminating the program, which is appropriate for a UEFI
+/// application.
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo,) -> ! {
 	println!("{panic:#?}");
@@ -144,7 +150,14 @@ pub fn init(image_handle: UnsafeHandle, syst: *const SystemTable,) {
 	// Connect each device, ignoring connection errors
 	handles.iter().for_each(|handle| {
 		// Ignore errors from connect_controller intentionally
-		unsafe { bs.connect_controller(*handle, None, None, raw::types::Boolean::TRUE,) };
+		unsafe {
+			bs.connect_controller(
+				*handle,
+				None,
+				None,
+				raw::types::Boolean::TRUE,
+			)
+		};
 	},);
 }
 
@@ -177,7 +190,8 @@ fn into_null_terminated_utf16(s: impl AsRef<str,>,) -> Vec<u16,> {
 ///
 /// # Returns
 ///
-/// * `Ok(NonNull<ConfigTable>)` - Pointer to the device tree configuration table
+/// * `Ok(NonNull<ConfigTable>)` - Pointer to the device tree configuration
+///   table
 /// * `Err(UefiError)` - If the device tree cannot be found or accessed
 ///
 /// # Errors
@@ -237,7 +251,9 @@ pub fn exec_kernel(kernel_entry: u64, device_tree_ptr: DeviceTreeAddress,) {
 	#[cfg(target_arch = "x86_64")]
 	type KernelEntry = extern "sysv64" fn(DeviceTreeAddress,);
 
-	let entry_point = unsafe { core::mem::transmute::<*const (), KernelEntry,>(kernel_entry,) };
+	let entry_point = unsafe {
+		core::mem::transmute::<*const (), KernelEntry,>(kernel_entry,)
+	};
 
 	// Architecture-specific preparation for kernel execution
 	#[cfg(target_arch = "aarch64")]

--- a/oso_loader/src/load.rs
+++ b/oso_loader/src/load.rs
@@ -1,7 +1,7 @@
 //! # Kernel and Graphics Loading Module
 //!
-//! This module provides functionality for loading ELF kernels from the filesystem
-//! and configuring graphics output for the kernel environment.
+//! This module provides functionality for loading ELF kernels from the
+//! filesystem and configuring graphics output for the kernel environment.
 
 use crate::Rslt;
 use crate::chibi_uefi::required_pages;
@@ -107,17 +107,21 @@ fn open_kernel_file() -> Rslt<NonNull<FileProtocolV1,>,> {
 	let bs = boot_services();
 
 	// Locate the file system protocol
-	let sfs_handle = unsafe { bs.handle_for_protocol::<SimpleFileSystemProtocol>() }?;
+	let sfs_handle =
+		unsafe { bs.handle_for_protocol::<SimpleFileSystemProtocol>() }?;
 
 	// Open the root volume
 	let volume = unsafe {
-		bs.open_protocol_exclusive::<SimpleFileSystemProtocol>(sfs_handle,)?.interface().as_mut()
+		bs.open_protocol_exclusive::<SimpleFileSystemProtocol>(sfs_handle,)?
+			.interface()
+			.as_mut()
 	}
 	.open_volume()?;
 
 	// Open the kernel file
 	let kernel_file = volume.open("oso_kernel.elf", open_mode, attrs,)?;
-	let non_null_kernel_file = NonNull::new(kernel_file,).expect("reference can't be null",);
+	let non_null_kernel_file =
+		NonNull::new(kernel_file,).expect("reference can't be null",);
 	Ok(non_null_kernel_file,)
 }
 
@@ -191,8 +195,12 @@ fn copy_load_segment(elf: &Elf, src: &[u8],) {
 
 		// Memory size may be larger than file size due to .bss section
 		let mem_size = ph.memory_size as usize;
-		let dest =
-			unsafe { core::slice::from_raw_parts_mut(ph.virtual_address as *mut u8, mem_size,) };
+		let dest = unsafe {
+			core::slice::from_raw_parts_mut(
+				ph.virtual_address as *mut u8,
+				mem_size,
+			)
+		};
 
 		let offset = ph.offset as usize;
 		let file_size = ph.file_size as usize;
@@ -234,7 +242,8 @@ pub fn graphic_config() -> Rslt<FrameBufConf,> {
 	let bs = boot_services();
 
 	// Open Graphics Output Protocol
-	let mut gout = bs.open_protocol_with::<GraphicsOutputProtocol>()?.interface();
+	let mut gout =
+		bs.open_protocol_with::<GraphicsOutputProtocol>()?.interface();
 	let gout = unsafe { gout.as_mut() };
 
 	// Query current graphics mode information
@@ -246,7 +255,8 @@ pub fn graphic_config() -> Rslt<FrameBufConf,> {
 	let pixel_format = info.pixel_format();
 
 	// Create frame buffer configuration
-	let fbc = FrameBufConf::new(pixel_format, base, size, width, height, stride,);
+	let fbc =
+		FrameBufConf::new(pixel_format, base, size, width, height, stride,);
 
 	Ok(fbc,)
 }

--- a/oso_loader/src/main.rs
+++ b/oso_loader/src/main.rs
@@ -1,7 +1,8 @@
 //! # OSO Loader Main Entry Point
 //!
-//! This module contains the main UEFI application entry point for the OSO bootloader.
-//! It orchestrates the boot process from UEFI initialization through kernel handoff.
+//! This module contains the main UEFI application entry point for the OSO
+//! bootloader. It orchestrates the boot process from UEFI initialization
+//! through kernel handoff.
 
 #![no_std]
 #![no_main]
@@ -60,7 +61,8 @@ pub extern "efiapi" fn efi_image_entry_point(
 	init(image_handle, system_table,);
 
 	// Load kernel and prepare for execution
-	let (kernel_entry, device_tree_ptr,) = app().expect("error arise while executing application",);
+	let (kernel_entry, device_tree_ptr,) =
+		app().expect("error arise while executing application",);
 
 	// Exit UEFI boot services - point of no return
 	exit_boot_services();

--- a/oso_loader/src/raw/protocol/file.rs
+++ b/oso_loader/src/raw/protocol/file.rs
@@ -10,8 +10,10 @@ use crate::raw::types::file::OpenMode;
 #[repr(C)]
 pub struct SimpleFileSystemProtocol {
 	pub revision:    u64,
-	pub open_volume:
-		unsafe extern "efiapi" fn(this: *mut Self, root: *mut *mut FileProtocolV1,) -> Status,
+	pub open_volume: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		root: *mut *mut FileProtocolV1,
+	) -> Status,
 }
 
 /**
@@ -116,7 +118,8 @@ The operation will wait for all pending asynchronous I/O requests to complete be
 |EFI_SUCCESS|The file was closed|
 
 */
-type FileClose = unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
+type FileClose =
+	unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
 
 /**
 ---
@@ -134,7 +137,8 @@ The Delete() function closes and deletes a file. In all cases the file handle is
 |EFI_WARN_DELETE_FAILURE |The handle was closed, but the file was not deleted|
 
 */
-type FileDelete = unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
+type FileDelete =
+	unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
 
 /**
 ---
@@ -259,8 +263,10 @@ The address to return the file’s current position value.
 |EFI_DEVICE_ERROR |An attempt was made to get the position from a deleted file|
 
 */
-type FileGetPosition =
-	unsafe extern "efiapi" fn(this: *const FileProtocolV1, position: *mut u64,) -> Status;
+type FileGetPosition = unsafe extern "efiapi" fn(
+	this: *const FileProtocolV1,
+	position: *mut u64,
+) -> Status;
 
 /**
 ---
@@ -293,8 +299,10 @@ The byte position from the start of the file to set.
 |EFI_DEVICE_ERROR |An attempt was made to set the position of a deleted file|
 
 */
-type FileSetPosition =
-	unsafe extern "efiapi" fn(this: *mut FileProtocolV1, position: u64,) -> Status;
+type FileSetPosition = unsafe extern "efiapi" fn(
+	this: *mut FileProtocolV1,
+	position: u64,
+) -> Status;
 
 /**
 ---
@@ -424,7 +432,8 @@ The Flush() function flushes all modified data associated with a file to a devic
 |EFI_VOLUME_FULL |The volume is full|
 
 */
-type FileFlush = unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
+type FileFlush =
+	unsafe extern "efiapi" fn(this: *mut FileProtocolV1,) -> Status;
 
 /**
 ---
@@ -563,8 +572,10 @@ Type EFI_FILE_IO_TOKEN is defined in “Related Definitions” below.
 |EFI_OUT_OF_RESOURCES |Unable to queue the request due to lack of resources|
 
 */
-type FileReadEx =
-	unsafe extern "efiapi" fn(this: *mut FileProtocolV2, token: *mut FileIoToken,) -> Status;
+type FileReadEx = unsafe extern "efiapi" fn(
+	this: *mut FileProtocolV2,
+	token: *mut FileIoToken,
+) -> Status;
 
 /**
 ---
@@ -620,8 +631,10 @@ Type EFI_FILE_IO_TOKEN is defined in “Related Definitions” above.
 |EFI_OUT_OF_RESOURCES |Unable to queue the request due to lack of resources|
 
 */
-type FileWriteEx =
-	unsafe extern "efiapi" fn(this: *mut FileProtocolV2, token: *mut FileIoToken,) -> Status;
+type FileWriteEx = unsafe extern "efiapi" fn(
+	this: *mut FileProtocolV2,
+	token: *mut FileIoToken,
+) -> Status;
 
 /**
 ---
@@ -662,8 +675,10 @@ The BufferSize and Buffer fields are not used for a FlushEx operation.
 |EFI_OUT_OF_RESOURCES |Unable to queue the request due to lack of resources|
 
 */
-type FileFlushEx =
-	unsafe extern "efiapi" fn(this: *mut FileProtocolV2, token: *mut FileIoToken,) -> Status;
+type FileFlushEx = unsafe extern "efiapi" fn(
+	this: *mut FileProtocolV2,
+	token: *mut FileIoToken,
+) -> Status;
 
 #[repr(C)]
 pub struct FileProtocolV1 {

--- a/oso_loader/src/raw/protocol/graphic.rs
+++ b/oso_loader/src/raw/protocol/graphic.rs
@@ -13,7 +13,8 @@ pub struct GraphicsOutputProtocol {
 		size_of_info: *mut usize,
 		info: *mut *const GraphicsOutputModeInfo,
 	) -> Status,
-	pub set_mode:   unsafe extern "efiapi" fn(*mut Self, mode_number: u32,) -> Status,
+	pub set_mode:
+		unsafe extern "efiapi" fn(*mut Self, mode_number: u32,) -> Status,
 	pub blt: unsafe extern "efiapi" fn(
 		*mut Self,
 		blt_buffer: *mut GraphicsOutputBltPixel,
@@ -33,14 +34,19 @@ impl GraphicsOutputProtocol {
 	pub fn query_mode(&self, index: u32,) {
 		let mut info_size = 0;
 		let mut info_heap_ptr = core::ptr::null();
-		let _ = unsafe { (self.query_mode)(self, index, &mut info_size, &mut info_heap_ptr,) }
-			.ok_or_with(|_| {
-				let _info = unsafe { *info_heap_ptr };
-				let info_heap_ptr =
-					unsafe { info_heap_ptr.cast::<u8>().cast_mut().as_mut().unwrap() };
+		let _ = unsafe {
+			(self.query_mode)(self, index, &mut info_size, &mut info_heap_ptr,)
+		}
+		.ok_or_with(|_| {
+			let _info = unsafe { *info_heap_ptr };
+			let info_heap_ptr = unsafe {
+				info_heap_ptr.cast::<u8>().cast_mut().as_mut().unwrap()
+			};
 
-				boot_services().free_pool(info_heap_ptr,).expect("buffer should be deallocatable",);
-			},);
+			boot_services()
+				.free_pool(info_heap_ptr,)
+				.expect("buffer should be deallocatable",);
+		},);
 	}
 
 	pub fn mode(&self,) -> &GraphicsOutputProtocolMode {

--- a/oso_loader/src/raw/protocol/text.rs
+++ b/oso_loader/src/raw/protocol/text.rs
@@ -9,27 +9,51 @@ use oso_error::loader::UefiError;
 
 #[repr(C)]
 pub struct TextInputProtocol {
-	reset:           unsafe extern "efiapi" fn(this: *mut Self, extended_verif: Boolean,) -> Status,
-	read_key_stroke: unsafe extern "efiapi" fn(this: *mut Self, key: *const InputKey,) -> Status,
+	reset: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		extended_verif: Boolean,
+	) -> Status,
+	read_key_stroke: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		key: *const InputKey,
+	) -> Status,
 	wait_for_key:    *mut c_void,
 }
 
 #[repr(C)]
 pub struct TextOutputProtocol {
-	reset:         unsafe extern "efiapi" fn(this: *mut Self, extended_verif: Boolean,) -> Status,
-	output:        unsafe extern "efiapi" fn(this: *mut Self, string: *const u16,) -> Status,
-	test:          unsafe extern "efiapi" fn(this: *mut Self, string: *const u16,) -> Status,
+	reset: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		extended_verif: Boolean,
+	) -> Status,
+	output: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		string: *const u16,
+	) -> Status,
+	test: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		string: *const u16,
+	) -> Status,
 	query_mode: unsafe extern "efiapi" fn(
 		this: *mut Self,
 		mode_number: usize,
 		columns: *mut usize,
 		rows: *mut usize,
 	),
-	set_mode:      unsafe extern "efiapi" fn(this: *mut Self, mode_number: usize,) -> Status,
-	set_attr:      unsafe extern "efiapi" fn(this: *mut Self, attribute: usize,) -> Status,
+	set_mode: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		mode_number: usize,
+	) -> Status,
+	set_attr:
+		unsafe extern "efiapi" fn(this: *mut Self, attribute: usize,) -> Status,
 	clear:         unsafe extern "efiapi" fn(this: *mut Self,) -> Status,
-	set_cursor:    unsafe extern "efiapi" fn(this: *mut Self, column: usize, row: usize,) -> Status,
-	enable_cursor: unsafe extern "efiapi" fn(this: *mut Self, visible: Boolean,) -> Status,
+	set_cursor: unsafe extern "efiapi" fn(
+		this: *mut Self,
+		column: usize,
+		row: usize,
+	) -> Status,
+	enable_cursor:
+		unsafe extern "efiapi" fn(this: *mut Self, visible: Boolean,) -> Status,
 	mode:          TextOutputModePtr,
 }
 

--- a/oso_loader/src/raw/service.rs
+++ b/oso_loader/src/raw/service.rs
@@ -27,11 +27,18 @@ pub struct RuntimeServices {
 	header: Header,
 
 	// time services
-	pub get_time: unsafe extern "efiapi" fn(time: *mut Time, *mut TimeCapabilities,) -> Status,
-	pub set_time:        unsafe extern "efiapi" fn(time: *const Time,) -> Status,
-	pub get_wakeup_time:
-		unsafe extern "efiapi" fn(enabled: *mut u8, pending: *mut u8, time: *mut Time,) -> Status,
-	pub set_wakeup_time: unsafe extern "efiapi" fn(enable: u8, time: *const Time,) -> Status,
+	pub get_time: unsafe extern "efiapi" fn(
+		time: *mut Time,
+		*mut TimeCapabilities,
+	) -> Status,
+	pub set_time: unsafe extern "efiapi" fn(time: *const Time,) -> Status,
+	pub get_wakeup_time: unsafe extern "efiapi" fn(
+		enabled: *mut u8,
+		pending: *mut u8,
+		time: *mut Time,
+	) -> Status,
+	pub set_wakeup_time:
+		unsafe extern "efiapi" fn(enable: u8, time: *const Time,) -> Status,
 
 	// virtual memory services
 	pub set_virtual_address_map: unsafe extern "efiapi" fn(
@@ -40,9 +47,10 @@ pub struct RuntimeServices {
 		descriptor_version: u32,
 		virtual_map: *mut MemoryDescriptor,
 	) -> Status,
-	pub convert_pointer:
-		unsafe extern "efiapi" fn(debug_dispositioon: usize, address: *mut *const c_void,)
-			-> Status,
+	pub convert_pointer: unsafe extern "efiapi" fn(
+		debug_dispositioon: usize,
+		address: *mut *const c_void,
+	) -> Status,
 
 	// variable services
 	pub get_variable: unsafe extern "efiapi" fn(
@@ -66,7 +74,8 @@ pub struct RuntimeServices {
 	) -> Status,
 
 	// miscellaneous
-	pub get_next_high_monotonic_count: unsafe extern "efiapi" fn(count: *mut u32,) -> Status,
+	pub get_next_high_monotonic_count:
+		unsafe extern "efiapi" fn(count: *mut u32,) -> Status,
 	pub reset_system: unsafe extern "efiapi" fn(
 		reset_type: ResetType,
 		reset_status: Status,
@@ -111,7 +120,10 @@ pub struct BootServices {
 		pages: usize,
 		memory: *mut PhysicalAddress,
 	) -> Status,
-	pub free_pages:     unsafe extern "efiapi" fn(memory: PhysicalAddress, pages: usize,) -> Status,
+	pub free_pages: unsafe extern "efiapi" fn(
+		memory: PhysicalAddress,
+		pages: usize,
+	) -> Status,
 	pub get_memory_map: unsafe extern "efiapi" fn(
 		memory_map_size: *mut usize,
 		memory_map: *mut MemoryDescriptor,
@@ -130,13 +142,17 @@ pub struct BootServices {
 	pub create_event: unsafe extern "efiapi" fn(
 		event_type: EventType,
 		notify_tpl: Tpl,
-		notify_function: Option<unsafe extern "efiapi" fn(event: Event, context: *mut c_void,),>,
+		notify_function: Option<
+			unsafe extern "efiapi" fn(event: Event, context: *mut c_void,),
+		>,
 		notify_context: *mut c_void,
 		event: *mut Event,
 	) -> Status,
-	pub set_timer:
-		unsafe extern "efiapi" fn(event: Event, time_type: TimerDelay, trigger_time: u64,)
-			-> Status,
+	pub set_timer: unsafe extern "efiapi" fn(
+		event: Event,
+		time_type: TimerDelay,
+		trigger_time: u64,
+	) -> Status,
 	pub wait_for_event: unsafe extern "efiapi" fn(
 		number_of_events: usize,
 		event: *mut Event,
@@ -187,8 +203,10 @@ pub struct BootServices {
 		device_path: *mut *const DevicePathProtocol,
 		device: *mut *mut c_void,
 	) -> Status,
-	pub install_configuration_table:
-		unsafe extern "efiapi" fn(guid: *const Guid, table: *const c_void,) -> Status,
+	pub install_configuration_table: unsafe extern "efiapi" fn(
+		guid: *const Guid,
+		table: *const c_void,
+	) -> Status,
 
 	// image services
 	pub load_image: unsafe extern "efiapi" fn(
@@ -210,13 +228,17 @@ pub struct BootServices {
 		exit_data_size: usize,
 		exit_data: *mut Char16,
 	) -> Status,
-	pub unload_image:       unsafe extern "efiapi" fn(image_handle: UnsafeHandle,) -> Status,
-	pub exit_boot_services:
-		unsafe extern "efiapi" fn(image_handle: UnsafeHandle, map_key: usize,) -> Status,
+	pub unload_image:
+		unsafe extern "efiapi" fn(image_handle: UnsafeHandle,) -> Status,
+	pub exit_boot_services: unsafe extern "efiapi" fn(
+		image_handle: UnsafeHandle,
+		map_key: usize,
+	) -> Status,
 
 	// miscellaneous services
-	pub get_next_monotonic_count: unsafe extern "efiapi" fn(count: *mut u64,) -> Status,
-	pub stall:                    unsafe extern "efiapi" fn(micro_second: usize,) -> Status,
+	pub get_next_monotonic_count:
+		unsafe extern "efiapi" fn(count: *mut u64,) -> Status,
+	pub stall: unsafe extern "efiapi" fn(micro_second: usize,) -> Status,
 	pub set_watchdog_timer: unsafe extern "efiapi" fn(
 		timeout: usize,
 		watchdog_code: u64,
@@ -281,17 +303,26 @@ pub struct BootServices {
 		unsafe extern "C" fn(handle: UnsafeHandle, ...) -> Status,
 
 	// crc services
-	pub calculate_crc32:
-		unsafe extern "efiapi" fn(data: *const c_void, data_size: usize, crc32: *mut u32,)
-			-> Status,
+	pub calculate_crc32: unsafe extern "efiapi" fn(
+		data: *const c_void,
+		data_size: usize,
+		crc32: *mut u32,
+	) -> Status,
 
 	// misc services
-	pub copy_mem:        unsafe extern "efiapi" fn(dest: *mut u8, source: *const u8, len: usize,),
-	pub set_mem:         unsafe extern "efiapi" fn(buf: *mut u8, size: usize, value: u8,),
+	pub copy_mem: unsafe extern "efiapi" fn(
+		dest: *mut u8,
+		source: *const u8,
+		len: usize,
+	),
+	pub set_mem:
+		unsafe extern "efiapi" fn(buf: *mut u8, size: usize, value: u8,),
 	pub create_event_ex: unsafe extern "efiapi" fn(
 		event_type: EventType,
 		notify_tpl: Tpl,
-		notify_function: Option<unsafe extern "efiapi" fn(event: Event, context: *mut c_void,),>,
+		notify_function: Option<
+			unsafe extern "efiapi" fn(event: Event, context: *mut c_void,),
+		>,
 		notify_context: *mut c_void,
 		event_group: *mut Guid,
 		event: *mut Event,

--- a/oso_loader/src/raw/table.rs
+++ b/oso_loader/src/raw/table.rs
@@ -56,7 +56,8 @@ impl ConfigTableStream {
 			let target_config_table = unsafe { config_tables.as_ptr().add(i,) };
 
 			let config_table = unsafe {
-				// `config_tables.as_ptr().add(i)`は本来nullではないはずなのでunsafeしても良さげ
+				// `config_tables.as_ptr().
+				// add(i)`は本来nullではないはずなのでunsafeしても良さげ
 				NonNull::new_unchecked(target_config_table,)
 			};
 
@@ -69,12 +70,16 @@ impl ConfigTableStream {
 	}
 }
 
-pub const DEVICE_TREE_TABLE_GUID: Guid = guid!("b1b621d5-f19c-41a5-830b-d9152c69aae0");
+pub const DEVICE_TREE_TABLE_GUID: Guid =
+	guid!("b1b621d5-f19c-41a5-830b-d9152c69aae0");
 
 impl SystemTable {
 	pub fn get_config_tables(&self,) -> Rslt<ConfigTableStream, UefiError,> {
 		let config_tables = NonNull::new(self.config_tables,);
-		Ok(ConfigTableStream { max_index: self.config_table_count, config_tables, },)
+		Ok(ConfigTableStream {
+			max_index: self.config_table_count,
+			config_tables,
+		},)
 	}
 
 	pub fn config_table_with(
@@ -84,7 +89,9 @@ impl SystemTable {
 		Ok(self.get_config_tables()?.config_table_with(guid,),)
 	}
 
-	pub fn device_tree(&self,) -> Rslt<Option<NonNull<ConfigTable,>,>, UefiError,> {
+	pub fn device_tree(
+		&self,
+	) -> Rslt<Option<NonNull<ConfigTable,>,>, UefiError,> {
 		self.config_table_with(DEVICE_TREE_TABLE_GUID,)
 	}
 }

--- a/oso_loader/src/raw/types.rs
+++ b/oso_loader/src/raw/types.rs
@@ -75,11 +75,19 @@ impl Guid {
 		clock_seq_low: u8,
 		node: [u8; 6],
 	) -> Self {
-		let time_low = u32::from_ne_bytes([time_low[0], time_low[1], time_low[2], time_low[3],],);
+		let time_low = u32::from_ne_bytes([
+			time_low[0],
+			time_low[1],
+			time_low[2],
+			time_low[3],
+		],);
 		Self {
 			time_low,
 			time_mid: [time_mid[0], time_mid[1],],
-			time_high_and_version: [time_high_and_version[0], time_high_and_version[1],],
+			time_high_and_version: [
+				time_high_and_version[0],
+				time_high_and_version[1],
+			],
 			clock_seq_high_and_reserved,
 			clock_seq_low,
 			node,

--- a/oso_loader/src/raw/types/memory.rs
+++ b/oso_loader/src/raw/types/memory.rs
@@ -49,8 +49,10 @@ c_style_enum! {
 }
 
 impl MemoryType {
-	pub const RESERVED_FOR_OEM: RangeInclusive<u32,> = 0x7000_0000..=0x7fff_ffff;
-	pub const RESERVED_FOR_OS_LOADER: RangeInclusive<u32,> = 0x8000_0000..=0xffff_ffff;
+	pub const RESERVED_FOR_OEM: RangeInclusive<u32,> =
+		0x7000_0000..=0x7fff_ffff;
+	pub const RESERVED_FOR_OS_LOADER: RangeInclusive<u32,> =
+		0x8000_0000..=0xffff_ffff;
 
 	pub const fn custom(value: u32,) -> Self {
 		assert!(value >= 0x8000_0000);
@@ -136,7 +138,8 @@ impl MemoryMapBackingMemory {
 	unsafe fn from_raw(alloc_pos: *mut u8, len: usize,) -> Self {
 		assert_eq!(alloc_pos.align_offset(align_of::<MemoryDescriptor,>()), 0);
 
-		let ptr = NonNull::new(alloc_pos,).expect("uefi should never return null ptr",);
+		let ptr = NonNull::new(alloc_pos,)
+			.expect("uefi should never return null ptr",);
 		let slice = NonNull::slice_from_raw_parts(ptr, len,);
 
 		Self(slice,)
@@ -161,7 +164,10 @@ pub struct MemoryMapOwned {
 }
 
 impl MemoryMapOwned {
-	pub fn from_initialized_memory(buf: MemoryMapBackingMemory, info: MemoryMapInfo,) -> Self {
+	pub fn from_initialized_memory(
+		buf: MemoryMapBackingMemory,
+		info: MemoryMapInfo,
+	) -> Self {
 		assert!(info.desc_size >= size_of::<MemoryDescriptor,>());
 
 		let len = info.entry_count();


### PR DESCRIPTION
Purpose
- refactor(oso_loader): reorganize UEFI and ELF loading modules

Details
- Branch groups       20 file(s) related to refactor/oso-loader
- See commit for rationale and scope

Included paths (sample)
- oso_loader/src/chibi_uefi.rs
- oso_loader/src/chibi_uefi/fs.rs
- oso_loader/src/chibi_uefi/guid.rs
- oso_loader/src/chibi_uefi/memory.rs
- oso_loader/src/chibi_uefi/protocol.rs
- oso_loader/src/chibi_uefi/table.rs
- oso_loader/src/elf.rs
- oso_loader/src/elf/hash.rs
- oso_loader/src/elf/program_header.rs
- oso_loader/src/elf/section_header.rs