### PR TITLE
refactor(oso_no_std_shared): refine data and bridge types

### DIFF
--- a/oso_no_std_shared/src/bridge.rs
+++ b/oso_no_std_shared/src/bridge.rs
@@ -1,10 +1,12 @@
 //! # OSO Bridge
 //!
-//! `oso_bridge` is a no_std crate that provides low-level interfaces and utilities for
-//! operating system development, particularly focused on bare-metal environments.
+//! `oso_bridge` is a no_std crate that provides low-level interfaces and
+//! utilities for operating system development, particularly focused on
+//! bare-metal environments.
 //!
-//! This crate serves as a bridge between hardware and the operating system kernel,
-//! providing essential primitives for CPU control, framebuffer management, and device tree access.
+//! This crate serves as a bridge between hardware and the operating system
+//! kernel, providing essential primitives for CPU control, framebuffer
+//! management, and device tree access.
 //!
 //! ## Features
 //!
@@ -14,8 +16,8 @@
 //!
 //! ## Usage
 //!
-//! This crate is designed to be used in no_std environments, typically in kernel or bootloader
-//! code:
+//! This crate is designed to be used in no_std environments, typically in
+//! kernel or bootloader code:
 //!
 //! ```rust,no_run
 //! use oso_no_std_shared::bridge::graphic::FrameBufConf;

--- a/oso_no_std_shared/src/bridge/graphic.rs
+++ b/oso_no_std_shared/src/bridge/graphic.rs
@@ -14,14 +14,16 @@
 //! ## Key Components
 //!
 //! - [`PixelFormatConf`]: Enum representing different pixel formats
-//! - [`FrameBufConf`]: Structure containing framebuffer configuration parameters
+//! - [`FrameBufConf`]: Structure containing framebuffer configuration
+//!   parameters
 //!
 //! ## Design Principles
 //!
 //! - **ABI Stability**: Uses `#[repr(C)]` for consistent memory layout
 //! - **No Standard Library**: Works in `no_std` environments
 //! - **Safety**: Provides safe abstractions over raw hardware interfaces
-//! - **Flexibility**: Supports multiple pixel formats and display configurations
+//! - **Flexibility**: Supports multiple pixel formats and display
+//!   configurations
 //!
 //! ## Usage Scenarios
 //!
@@ -49,7 +51,8 @@
 //!
 //! ### Kernel Graphics Initialization
 //!
-//! The kernel receives the configuration and initializes its graphics subsystem:
+//! The kernel receives the configuration and initializes its graphics
+//! subsystem:
 //!
 //! ```rust,no_run
 //! // Kernel code
@@ -70,7 +73,8 @@
 //!
 //! The framebuffer memory layout depends on the pixel format and stride:
 //!
-//! - **Stride**: May be larger than `width * bytes_per_pixel` due to alignment requirements
+//! - **Stride**: May be larger than `width * bytes_per_pixel` due to alignment
+//!   requirements
 //! - **Padding**: Some hardware requires row padding for optimal performance
 //! - **Endianness**: Pixel format determines byte order within each pixel
 //!
@@ -83,9 +87,9 @@
 
 /// Represents the pixel format configuration for a framebuffer
 ///
-/// This enum defines the different pixel formats that can be used when configuring
-/// a framebuffer for graphics output. Each format represents a different way of
-/// organizing color data within each pixel.
+/// This enum defines the different pixel formats that can be used when
+/// configuring a framebuffer for graphics output. Each format represents a
+/// different way of organizing color data within each pixel.
 ///
 /// # Pixel Format Details
 ///
@@ -139,7 +143,8 @@
 ///
 /// - **RGB/BGR**: Direct pixel access, good for individual pixel operations
 /// - **Bitmask**: May require additional computation for color conversion
-/// - **BltOnly**: Optimized for bulk operations, limited individual pixel access
+/// - **BltOnly**: Optimized for bulk operations, limited individual pixel
+///   access
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy,)]
 pub enum PixelFormatConf {
@@ -192,8 +197,8 @@ impl PixelFormatConf {
 	/// ```
 	pub fn bytes_per_pixel(&self,) -> Option<usize,> {
 		match self {
-			PixelFormatConf::Rgb | PixelFormatConf::Bgr => Some(4,), // Assuming 32-bit RGBA/BGRA
-			PixelFormatConf::Bitmask | PixelFormatConf::BltOnly => None, // Variable or unknown
+			PixelFormatConf::Rgb | PixelFormatConf::Bgr => Some(4,), /* Assuming 32-bit RGBA/BGRA */
+			PixelFormatConf::Bitmask | PixelFormatConf::BltOnly => None, /* Variable or unknown */
 		}
 	}
 
@@ -219,7 +224,9 @@ impl PixelFormatConf {
 	/// ```
 	pub fn supports_pixel_access(&self,) -> bool {
 		match self {
-			PixelFormatConf::Rgb | PixelFormatConf::Bgr | PixelFormatConf::Bitmask => true,
+			PixelFormatConf::Rgb
+			| PixelFormatConf::Bgr
+			| PixelFormatConf::Bitmask => true,
 			PixelFormatConf::BltOnly => false,
 		}
 	}
@@ -246,9 +253,10 @@ impl PixelFormatConf {
 ///
 /// ## ABI Stability
 ///
-/// Since Rust doesn't have a stabilized ABI, this structure uses the `#[repr(C)]`
-/// attribute to ensure a consistent memory layout when passed between components
-/// compiled with different versions of Rust or different compilers.
+/// Since Rust doesn't have a stabilized ABI, this structure uses the
+/// `#[repr(C)]` attribute to ensure a consistent memory layout when passed
+/// between components compiled with different versions of Rust or different
+/// compilers.
 ///
 /// ## Memory Layout
 ///
@@ -263,8 +271,8 @@ impl PixelFormatConf {
 /// ```
 ///
 /// The `stride` field indicates the number of bytes from the start of one row
-/// to the start of the next row, which may be larger than `width * bytes_per_pixel`
-/// due to alignment requirements.
+/// to the start of the next row, which may be larger than `width *
+/// bytes_per_pixel` due to alignment requirements.
 ///
 /// ## Fields
 ///
@@ -379,8 +387,8 @@ impl FrameBufConf {
 	///
 	/// # Panics
 	///
-	/// This function may panic in debug builds if the parameters are inconsistent
-	/// (e.g., if `stride * height > size`).
+	/// This function may panic in debug builds if the parameters are
+	/// inconsistent (e.g., if `stride * height > size`).
 	pub fn new(
 		pixel_format: PixelFormatConf,
 		base: *mut u8,
@@ -397,7 +405,10 @@ impl FrameBufConf {
 			stride >= width * pixel_format.bytes_per_pixel().unwrap_or(1),
 			"Stride must be at least width * bytes_per_pixel"
 		);
-		debug_assert!(stride * height <= size, "Total framebuffer size must accommodate all rows");
+		debug_assert!(
+			stride * height <= size,
+			"Total framebuffer size must accommodate all rows"
+		);
 
 		Self { pixel_format, size, base, width, height, stride, }
 	}
@@ -508,7 +519,11 @@ impl FrameBufConf {
 	/// ```
 	pub fn is_valid(&self,) -> bool {
 		// Basic sanity checks
-		if self.width == 0 || self.height == 0 || self.stride == 0 || self.size == 0 {
+		if self.width == 0
+			|| self.height == 0
+			|| self.stride == 0
+			|| self.size == 0
+		{
 			return false;
 		}
 

--- a/oso_no_std_shared/src/data.rs
+++ b/oso_no_std_shared/src/data.rs
@@ -1,12 +1,13 @@
 //! # Data Structures Module
 //!
-//! This module provides generic data structures and algorithms for use in the OSO
-//! operating system. The data structures are designed to work in `no_std` environments
-//! and provide efficient operations for system-level programming.
+//! This module provides generic data structures and algorithms for use in the
+//! OSO operating system. The data structures are designed to work in `no_std`
+//! environments and provide efficient operations for system-level programming.
 //!
 //! ## Submodules
 //!
-//! - `tree`: Generic tree data structure with traversal and manipulation capabilities
+//! - `tree`: Generic tree data structure with traversal and manipulation
+//!   capabilities
 
 pub mod list;
 pub mod node;

--- a/oso_no_std_shared/src/data/tree.rs
+++ b/oso_no_std_shared/src/data/tree.rs
@@ -16,9 +16,9 @@
 //! ## Design Principles
 //!
 //! The tree implementation uses lifetime parameters to ensure memory safety
-//! without requiring heap allocation, making it suitable for `no_std` environments.
-//! The trait-based design allows for flexible tree operations while maintaining
-//! type safety.
+//! without requiring heap allocation, making it suitable for `no_std`
+//! environments. The trait-based design allows for flexible tree operations
+//! while maintaining type safety.
 
 use crate::data::node::NodeValue;
 
@@ -27,7 +27,8 @@ pub mod walk_rslt;
 pub mod walker;
 
 //  TODO: -implement TreePart for Tree
-// - refactor codebase to use `TreePart` object as an atomic unit in `TreeWalk` and `TreeWindow`
+// - refactor codebase to use `TreePart` object as an atomic unit in `TreeWalk`
+//   and `TreeWindow`
 pub trait TreePart {
 	type N: NodeValue;
 

--- a/oso_no_std_shared/src/data/tree/walk_rslt.rs
+++ b/oso_no_std_shared/src/data/tree/walk_rslt.rs
@@ -103,7 +103,9 @@ pub struct WalkRslt<N: NodeValue, T: TreeWalker<N,>, C: Coordinate,> {
 	coord:        C,
 }
 
-impl<N: NodeValue, T: TreeWalker<N,>, C: Coordinate,> WalkTried for WalkRslt<N, T, C,> {
+impl<N: NodeValue, T: TreeWalker<N,>, C: Coordinate,> WalkTried
+	for WalkRslt<N, T, C,>
+{
 	type C = C;
 	type N = N;
 	type T = T;
@@ -125,6 +127,10 @@ impl<N: NodeValue, T: TreeWalker<N,>, C: Coordinate,> WalkTried for WalkRslt<N, 
 	}
 
 	fn from(tn: T, coord: Self::C,) -> Self {
-		Self { __constraint: core::marker::PhantomData::<N,>, tree: Some(tn,), coord, }
+		Self {
+			__constraint: core::marker::PhantomData::<N,>,
+			tree: Some(tn,),
+			coord,
+		}
 	}
 }

--- a/oso_no_std_shared/src/data/tree/walker.rs
+++ b/oso_no_std_shared/src/data/tree/walker.rs
@@ -66,8 +66,8 @@ pub trait TreeWindow<N: NodeValue,>: TreeWalker<N,> {
 /// # Design Notes
 ///
 /// - The `nth_ancestor` method has a default implementation for convenience
-/// - Border conditions (like reaching root or leaf nodes) are handled through the `WalkTried`
-///   return type
+/// - Border conditions (like reaching root or leaf nodes) are handled through
+///   the `WalkTried` return type
 /// - Position tracking is handled through the `Coordinate` trait
 ///
 /// # Type Parameters
@@ -133,7 +133,10 @@ pub trait TreeWalker<N: NodeValue,>: Sized + Iterator {
 			let mut parent = self.parent::<WT>();
 			if parent.has_success() {
 				// Successfully found parent, continue recursion
-				TreeWalker::nth_ancestor::<WT,>(parent.current_tree_mut().as_mut().unwrap(), n - 1,)
+				TreeWalker::nth_ancestor::<WT,>(
+					parent.current_tree_mut().as_mut().unwrap(),
+					n - 1,
+				)
 			} else {
 				// Failed to find parent, return the failure
 				parent
@@ -281,7 +284,11 @@ pub trait TreeWalker<N: NodeValue,>: Sized + Iterator {
 	fn set_pos<WT: WalkTried,>(&mut self, coordinate: impl Coordinate,) -> WT;
 
 	/// similar to `set_pos` but act as moving by relative distance
-	fn move_pos<WT: WalkTried,>(&mut self, dimension: usize, distance: isize,) -> WT;
+	fn move_pos<WT: WalkTried,>(
+		&mut self,
+		dimension: usize,
+		distance: isize,
+	) -> WT;
 
 	// === Position Information Methods ===
 

--- a/oso_no_std_shared/src/lib.rs
+++ b/oso_no_std_shared/src/lib.rs
@@ -3,21 +3,25 @@
 
 //! # OSO No-Std Shared Library
 //!
-//! This crate provides shared utilities and data structures for the OSO operating system
-//! that work in `no_std` environments. It serves as a foundational library containing
-//! common functionality used across different components of the OSO ecosystem.
+//! This crate provides shared utilities and data structures for the OSO
+//! operating system that work in `no_std` environments. It serves as a
+//! foundational library containing common functionality used across different
+//! components of the OSO ecosystem.
 //!
 //! ## Features
 //!
 //! - **Bridge Module**: Low-level hardware interfaces and CPU control functions
-//! - **Data Module**: Generic data structures like trees for system data management
-//! - **Parser Module**: Parsing utilities for binary data, HTML, and code generation
+//! - **Data Module**: Generic data structures like trees for system data
+//!   management
+//! - **Parser Module**: Parsing utilities for binary data, HTML, and code
+//!   generation
 //! - **CPU Control**: Platform-specific CPU power management functions
 //!
 //! ## Architecture
 //!
-//! This crate is designed to work in bare-metal environments and uses several unstable
-//! Rust features to provide zero-cost abstractions and compile-time optimizations.
+//! This crate is designed to work in bare-metal environments and uses several
+//! unstable Rust features to provide zero-cost abstractions and compile-time
+//! optimizations.
 //!
 //! ## Usage
 //!
@@ -57,8 +61,8 @@ use core::arch::asm;
 /// Puts the CPU into a low-power state until an interrupt occurs.
 ///
 /// This function enters an infinite loop where the CPU is repeatedly put into a
-/// wait-for-interrupt state. This is commonly used in bare-metal environments to
-/// conserve power when there's no work to be done.
+/// wait-for-interrupt state. This is commonly used in bare-metal environments
+/// to conserve power when there's no work to be done.
 ///
 /// # Platform-specific behavior
 ///
@@ -97,8 +101,9 @@ pub fn wfi() -> ! {
 /// Puts the CPU into a low-power state until an event occurs.
 ///
 /// This function enters an infinite loop where the CPU is repeatedly put into a
-/// wait-for-event state. This is similar to `wfi()` but responds to events rather
-/// than just interrupts, which can be useful in certain synchronization scenarios.
+/// wait-for-event state. This is similar to `wfi()` but responds to events
+/// rather than just interrupts, which can be useful in certain synchronization
+/// scenarios.
 ///
 /// # Platform-specific behavior
 ///

--- a/oso_no_std_shared/src/parser.rs
+++ b/oso_no_std_shared/src/parser.rs
@@ -1,8 +1,8 @@
 //! # Parser Module
 //!
-//! This module provides parsing utilities and code generation capabilities for the OSO
-//! operating system. It includes parsers for different data formats and a framework
-//! for building custom parsers.
+//! This module provides parsing utilities and code generation capabilities for
+//! the OSO operating system. It includes parsers for different data formats and
+//! a framework for building custom parsers.
 //!
 //! ## Submodules
 //!
@@ -13,8 +13,9 @@
 //! ## Design Philosophy
 //!
 //! The parser framework is built around traits that allow for composable and
-//! extensible parsing capabilities. The design emphasizes zero-cost abstractions
-//! and compile-time optimizations suitable for system-level programming.
+//! extensible parsing capabilities. The design emphasizes zero-cost
+//! abstractions and compile-time optimizations suitable for system-level
+//! programming.
 
 pub mod binary;
 pub mod generator;

--- a/oso_no_std_shared/src/parser/binary.rs
+++ b/oso_no_std_shared/src/parser/binary.rs
@@ -1,13 +1,14 @@
 //! # Binary Data Parsing Module
 //!
-//! This module provides specialized functionality for parsing binary data formats.
-//! It extends the core parser framework with binary-specific operations and
-//! utilities optimized for system-level binary data processing.
+//! This module provides specialized functionality for parsing binary data
+//! formats. It extends the core parser framework with binary-specific
+//! operations and utilities optimized for system-level binary data processing.
 //!
 //! ## Key Components
 //!
 //! - `BinaryParser<C>`: Trait for parsers that specifically handle binary data
-//! - `BinaryParserBuilder<T>`: Builder pattern implementation for constructing binary parsers
+//! - `BinaryParserBuilder<T>`: Builder pattern implementation for constructing
+//!   binary parsers
 //!
 //! ## Design Goals
 //!
@@ -31,9 +32,10 @@ use core::marker::PhantomData;
 
 /// Trait for parsers that specifically handle binary data formats.
 ///
-/// This trait extends the base `Parser` trait with binary-specific functionality.
-/// It serves as a marker trait to distinguish binary parsers from other parser
-/// types and may be extended in the future with binary-specific methods.
+/// This trait extends the base `Parser` trait with binary-specific
+/// functionality. It serves as a marker trait to distinguish binary parsers
+/// from other parser types and may be extended in the future with
+/// binary-specific methods.
 ///
 /// # Type Parameters
 ///
@@ -149,8 +151,8 @@ impl<T,> BinaryParserBuilder<T,> {
 	///
 	/// # Note
 	///
-	/// This method is currently commented out but represents future functionality
-	/// for handling different byte orders in binary data.
+	/// This method is currently commented out but represents future
+	/// functionality for handling different byte orders in binary data.
 	/// pub fn with_endianness(self, endianness: Endianness) -> Self {
 	///     // Configure endianness handling
 	///     self
@@ -167,8 +169,8 @@ impl<T,> BinaryParserBuilder<T,> {
 	///
 	/// # Note
 	///
-	/// This method is currently commented out but represents future functionality
-	/// for handling memory alignment requirements.
+	/// This method is currently commented out but represents future
+	/// functionality for handling memory alignment requirements.
 	/// pub fn with_alignment(self, alignment: usize) -> Self {
 	///     // Configure alignment requirements
 	///     self

--- a/oso_no_std_shared/src/parser/generator.rs
+++ b/oso_no_std_shared/src/parser/generator.rs
@@ -1,8 +1,8 @@
 //! # Parser Generation Framework
 //!
-//! This module provides the core traits and types for building composable parsers
-//! in the OSO operating system. The framework is designed around traits that allow
-//! for flexible parser construction and zero-cost abstractions.
+//! This module provides the core traits and types for building composable
+//! parsers in the OSO operating system. The framework is designed around traits
+//! that allow for flexible parser construction and zero-cost abstractions.
 //!
 //! ## Core Concepts
 //!
@@ -81,7 +81,8 @@ pub trait ParserGenerator<C: Context,> {
 ///
 /// # Associated Constants
 ///
-/// - `SIZE`: The size in bytes of the output type (defaults to `size_of::<Self::Output>()`)
+/// - `SIZE`: The size in bytes of the output type (defaults to
+///   `size_of::<Self::Output>()`)
 pub trait Context {
 	/// The type that will be produced by successful parsing
 	type Output;
@@ -128,8 +129,9 @@ pub trait Context {
 pub trait ParserComponents<C: Context,> {
 	/// Apply this parser component to the given context.
 	///
-	/// This method performs the parsing operation represented by this component,
-	/// potentially modifying the context and producing a result of type `R`.
+	/// This method performs the parsing operation represented by this
+	/// component, potentially modifying the context and producing a result of
+	/// type `R`.
 	///
 	/// # Type Parameters
 	///
@@ -141,7 +143,8 @@ pub trait ParserComponents<C: Context,> {
 	///
 	/// # Returns
 	///
-	/// A result containing either the parsed value of type `R` or a `ParserError`
+	/// A result containing either the parsed value of type `R` or a
+	/// `ParserError`
 	///
 	/// # Examples
 	///


### PR DESCRIPTION
Purpose
- refactor(oso_no_std_shared): refine data and bridge types

Details
- Branch groups       10 file(s) related to refactor/oso-no-std-shared
- See commit for rationale and scope

Included paths (sample)
- oso_no_std_shared/src/bridge.rs
- oso_no_std_shared/src/bridge/graphic.rs
- oso_no_std_shared/src/data.rs
- oso_no_std_shared/src/data/tree.rs
- oso_no_std_shared/src/data/tree/walk_rslt.rs
- oso_no_std_shared/src/data/tree/walker.rs
- oso_no_std_shared/src/lib.rs
- oso_no_std_shared/src/parser.rs
- oso_no_std_shared/src/parser/binary.rs
- oso_no_std_shared/src/parser/generator.rs