### PR TITLE
feat(xtask): add builder module

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,82 @@
+//! # Builder Module
+//!
+//! Core functionality for building the OSO loader and kernel, creating disk
+//! images, and running QEMU.
+//!
+//! This module handles:
+//! - Building the OSO loader and kernel for the target architecture
+//! - Creating and formatting a disk image
+//! - Mounting the disk image and copying the built artifacts
+//! - Configuring and running QEMU with the appropriate firmware and disk image
+//! - Cleanup of temporary files and unmounting disk images
+
+use anyhow::Result as Rslt;
+use oso_dev_util::cargo::Assets;
+use oso_dev_util::cargo::Opts;
+use oso_dev_util::fs::project_root;
+
+use crate::Xtask;
+
+/// Directory path for EFI boot files
+const BOOT_DIR: &str = "efi/boot";
+/// mounting point path under target/
+const MOUNT_DIR: &str = "xtask/mnt";
+
+impl Xtask {
+	/// Creates a new Builder instance with the specified options
+	///
+	/// This constructor initializes all the necessary components for the build
+	/// process:
+	/// - Parses command-line options and build configuration
+	/// - Sets up the OSO workspace with project paths
+	/// - Downloads and configures OVMF firmware for the target architecture
+	/// - Detects the host operating system for platform-specific operations
+	///
+	/// # Initialization Process
+	///
+	/// 1. **Options Parsing**: Reads command-line arguments for architecture,
+	///    build mode, etc.
+	/// 2. **Workspace Setup**: Locates project root and validates workspace
+	///    structure
+	/// 3. **Firmware Download**: Fetches appropriate OVMF firmware files for
+	///    UEFI boot
+	/// 4. **Host Detection**: Identifies the host OS (macOS, Linux) for mount
+	///    operations
+	///
+	/// # Returns
+	///
+	/// * `Ok(Builder)` - A fully initialized Builder instance ready for use
+	/// * `Err(anyhow::Error)` - If initialization fails due to:
+	///   - Invalid workspace structure
+	///   - Firmware download failure
+	///   - Unsupported host operating system
+	///   - Network connectivity issues
+	///
+	/// # Examples
+	///
+	/// ```rust,ignore
+	/// use xtask::builder::Builder;
+	///
+	/// // Create a builder with default configuration
+	/// let builder = Builder::new()?;
+	/// println!("Building for architecture: {:?}", builder.arch());
+	/// ```
+	///
+	/// # Errors
+	///
+	/// This method can fail in several scenarios:
+	/// - **Workspace Error**: If the OSO project structure is invalid or
+	///   incomplete
+	/// - **Firmware Error**: If OVMF firmware files cannot be downloaded or
+	///   accessed
+	/// - **Host OS Error**: If the host operating system is not supported
+	///   (Windows)
+	/// - **Network Error**: If firmware download requires internet access and
+	///   fails
+	pub fn new() -> Rslt<Self,> {
+		let opts = Opts::new();
+		let ws = project_root()?;
+		let assets = Assets::new(opts.arch,)?;
+		Ok(Self { opts, ws, assets, },)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+#![feature(string_from_utf8_lossy_owned)]
+#![feature(exit_status_error)]
+
+use oso_dev_util::cargo::Assets;
+use oso_dev_util::cargo::Opts;
+use oso_dev_util::decl_manage::crate_::OsoCrate;
+
+pub mod builder;
+pub mod qemu;
+
+pub struct Xtask {
+	opts:   Opts,
+	ws:     OsoCrate,
+	assets: Assets,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,69 @@
+#![feature(string_from_utf8_lossy_owned)]
+#![feature(exit_status_error)]
+
+//! # OSO xtask
+//!
+//! A build and run utility for the OSO project that automates the process of
+//! building, packaging, and running the OSO kernel and loader in QEMU.
+//!
+//! This crate provides a convenient way to:
+//! - Build the OSO loader (UEFI application) and kernel
+//! - Create and format a disk image
+//! - Mount the disk image and copy the built artifacts
+//! - Configure and run QEMU with the appropriate firmware and disk image
+//!
+//! ## Usage
+//!
+//! Run from the OSO project root:
+//!
+//! ```bash
+//! cargo run -p xtask [OPTIONS]
+//! ```
+//!
+//! ### Options
+//!
+//! - `-r`, `--release`: Build in release mode (default is debug mode)
+//! - `-86`, `-x86_64`: Build for x86_64 architecture (default is aarch64)
+//! - `--debug`: Enable debug mode with GDB support (listens on port 12345)
+
+use anyhow::Result as Rslt;
+use colored::Colorize;
+use oso_dev_util_helper::cli::Run;
+use std::process::Command;
+use xtask::builder::Builder;
+
+/// Entry point for the xtask utility.
+///
+/// Creates a new Builder instance, builds the OSO loader and kernel,
+/// and runs QEMU with the appropriate configuration.
+fn main() -> Rslt<(),> {
+	let builder = Builder::new()?;
+
+	let app = || {
+		builder.build()?;
+		builder.run()
+	};
+
+	match app() {
+		Ok(_,) => println!("\n\nprogram run successfully\nexit"),
+		Err(e,) => {
+			eprintln!(
+				"{} error msg:\n```rust\n{e:#?}\n```",
+				"program panicked".red().bold()
+			)
+		},
+	}
+
+	print_workspace()?;
+	Ok((),)
+}
+
+fn print_workspace() -> Rslt<(),> {
+	Command::new("eza",)
+		.args(
+			"-ahlF --icons --group-directories-first --sort=extension \
+			 --time-style=iso --git --no-user --no-time -T target/xtask"
+				.split_whitespace(),
+		)
+		.run()
+}

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -1,0 +1,172 @@
+//! # QEMU Module
+//!
+//! This module handles QEMU configuration and firmware management.
+//!
+//! It provides functionality for:
+//! - Configuring QEMU command-line arguments based on the target architecture
+//! - Managing OVMF firmware files for UEFI boot
+//! - Setting up block devices and persistent flash memory
+
+use anyhow::Result as Rslt;
+use oso_dev_util::cargo::Arch;
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::Xtask;
+
+impl Xtask {
+	/// Gets the QEMU executable name based on the target architecture
+	///
+	/// # Returns
+	///
+	/// The name of the QEMU executable (e.g., "qemu-system-aarch64")
+	pub fn qemu(&self,) -> String {
+		format!("qemu-system-{}", self.arch().to_string())
+	}
+
+	/// Generates QEMU command-line arguments based on the target architecture
+	/// and configuration
+	///
+	/// # Returns
+	///
+	/// A vector of command-line arguments for QEMU or an error if it fails
+	pub fn qemu_args(&self,) -> Rslt<Vec<String,>,> {
+		let mut args = basic_args(self.arch(),);
+
+		// configure persistent flash memory
+		let pflash_code = persistent_flash_memory_args(
+			&self.firmware_code()?,
+			PflashMode::ReadOnly,
+		);
+		let pflash_var = persistent_flash_memory_args(
+			&self.firmware_vars()?,
+			PflashMode::ReadWrite,
+		);
+		args.extend(pflash_code,);
+		args.extend(pflash_var,);
+
+		// args.extend(devices(),);
+
+		// let esp_dir = self.build_mount_point()?;
+		// args.push("-drive".to_string(),);
+		// args.push("format=raw,file=fat:rw:",);
+
+		let block_device = block_device(&self.disk_img_path()?,);
+		args.extend(block_device,);
+
+		// setting the boot menu timeout to zero particularly speeds up the boot
+		args.push("-boot".to_string(),);
+		args.push("menu=on,splash-time=0".to_string(),);
+
+		Ok(args,)
+	}
+}
+
+/// Manages OVMF firmware files for UEFI boot
+#[derive(Debug,)]
+pub struct Firmware {
+	/// Path to the OVMF code file
+	code: PathBuf,
+	/// Path to the OVMF variables file
+	vars: PathBuf,
+}
+
+/// Defines the mode for persistent flash memory
+enum PflashMode {
+	/// Read-only mode
+	ReadOnly,
+	/// Read-write mode
+	ReadWrite,
+}
+
+/// Generates basic QEMU arguments based on the target architecture
+///
+/// # Parameters
+///
+/// * `arch` - The target architecture
+///
+/// # Returns
+///
+/// A vector of basic QEMU command-line arguments
+fn basic_args(arch: Arch,) -> Vec<String,> {
+	match arch {
+		Arch::Aarch64 => vec![
+			// generic arm enviromnent
+			"-machine".to_string(),
+			"virt".to_string(),
+			// a72 is a very generic 64-bit arm cpu
+			"-cpu".to_string(),
+			"cortex-a72".to_string(),
+			// graphics device
+			"-device".to_string(),
+			"virtio-gpu-pci".to_string(),
+			// // keep using ramfb until implementing Linux-style driver
+			// "ramfb".to_string(),
+		],
+		Arch::Riscv64 => todo!(),
+		// Architecture::X86_64 => {
+		// 	vec![
+		// 		"-machine".to_string(),
+		// 		"q35".to_string(),
+		// 		"-smp".to_string(),
+		// 		"4".to_string(),
+		// 		// allocate some memory
+		// 		// "-m".to_string(),
+		// 		// "256M".to_string(),
+		//
+		// 		// graphics device
+		// 		"-vga".to_string(),
+		// 		"std".to_string(),
+		// 	]
+		// },
+	}
+}
+
+/// Generates QEMU arguments for persistent flash memory
+///
+/// # Parameters
+///
+/// * `pflash_file` - The path to the flash file
+/// * `mode` - The mode for the flash file (read-only or read-write)
+///
+/// # Returns
+///
+/// A vector of QEMU command-line arguments for persistent flash memory
+fn persistent_flash_memory_args(
+	pflash_file: &PathBuf,
+	mode: PflashMode,
+) -> Vec<String,> {
+	let mut args = vec!["-drive".to_string()];
+	let mut arg = String::from("if=pflash,format=raw,readonly=",);
+	arg.push_str(match mode {
+		PflashMode::ReadOnly => "on",
+		PflashMode::ReadWrite => "off",
+	},);
+
+	arg.push_str(",file=",);
+	arg.push_str(pflash_file.to_str().unwrap(),);
+	args.push(arg,);
+
+	args
+}
+
+/// Generates QEMU arguments for block devices
+///
+/// # Parameters
+///
+/// * `disk_img` - The path to the disk image
+/// * `arch` - The target architecture
+///
+/// # Returns
+///
+/// A vector of QEMU command-line arguments for block devices
+fn block_device(disk_img: &Path,) -> Vec<String,> {
+	vec![
+		"-monitor".to_string(),
+		"stdio".to_string(),
+		"-drive".to_string(),
+		format!("file={},format=raw,if=none,id=hd0", disk_img.display()),
+		"-device".to_string(),
+		"virtio-blk-pci,drive=hd0".to_string(),
+	]
+}


### PR DESCRIPTION
This PR introduces the xtask CLI foundation.\n\n- Adds builder module for orchestration\n- Integrates QEMU utilities for kernel runs\n- Provides CLI entrypoint and library helpers\n\nNo breaking changes expected.