### PR TITLE
delegate flake checks to xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
-xt = "run -q --package poison_girl --"
+xt = "run -q --package poison_girl --bin poison_girl --"
+xt-check = "run -q --package poison_girl --bin xtask-check"

--- a/flake.nix
+++ b/flake.nix
@@ -78,47 +78,20 @@
               cargoArtifacts = workspaceDeps;
             }
           );
-          mkCargoCheck =
-            args@{ cargoExtraArgs, ... }:
-            craneLib.mkCargoDerivation (
-              builtins.removeAttrs args [ "cargoExtraArgs" ]
-              // {
-                cargoArtifacts = null;
-                doInstallCargoArtifacts = false;
-                pnameSuffix = "-check";
-                buildPhaseCargoCommand = "cargoWithProfile check ${cargoExtraArgs}";
-                installPhaseCommand = "mkdir -p $out";
-              }
-            );
-          kernelAarch64Check = mkCargoCheck {
-            inherit src;
-            pname = "poison_girl-kernel-aarch64";
-            version = "0.1.0";
-            strictDeps = true;
-            cargoLock = ./Cargo.lock;
-            cargoExtraArgs = "-p poison_girl_kernel --locked --target aarch64-unknown-none";
-          };
-          loaderAarch64UefiCheck = mkCargoCheck {
-            inherit src;
-            pname = "poison_girl-loader-aarch64-uefi";
-            version = "0.1.0";
-            strictDeps = true;
-            cargoLock = ./Cargo.lock;
-            cargoExtraArgs = "-p poison_girl_loader --locked --target aarch64-unknown-uefi";
-          };
-          workspaceMetadata =
-            pkgs.runCommand "poison_girl-workspace-metadata"
-              {
-                nativeBuildInputs = [ rustToolchain ];
-              }
-              ''
-                export CARGO_HOME="$TMPDIR/cargo-home"
-                export RUSTUP_HOME="$TMPDIR/rustup-home"
-                cp -R ${src} source
-                chmod -R u+w source
-                cd source
-                cargo metadata --locked --no-deps --format-version 1 > "$out"
-              '';
+          xtaskCheck = craneLib.mkCargoDerivation (
+            workspaceArgs
+            // {
+              cargoArtifacts = workspaceDeps;
+              pname = "poison_girl";
+              version = "0.1.0";
+              pnameSuffix = "-xtask-check";
+              nativeBuildInputs = [ pkgs.cargo-nextest ];
+              doInstallCargoArtifacts = false;
+              buildPhaseCargoCommand =
+                "cargo run --locked --package poison_girl --bin xtask-check";
+              installPhaseCommand = "mkdir -p $out";
+            }
+          );
         in
         {
           formatter = pkgs.nixfmt;
@@ -126,38 +99,7 @@
             default = workspaceBuild;
           };
           checks = {
-            workspace_metadata = workspaceMetadata;
-            workspace_build = workspaceBuild;
-            workspace_clippy = craneLib.cargoClippy (
-              workspaceArgs
-              // {
-                cargoArtifacts = workspaceDeps;
-                cargoClippyExtraArgs = "--all-targets -- -D warnings";
-              }
-            );
-            workspace_test = craneLib.cargoNextest (
-              workspaceArgs
-              // {
-                cargoArtifacts = workspaceDeps;
-                cargoNextestExtraArgs = "--no-tests pass";
-                partitions = 1;
-                partitionType = "count";
-              }
-            );
-            workspace_doc = craneLib.cargoDoc (
-              workspaceArgs
-              // {
-                cargoArtifacts = workspaceDeps;
-                cargoDocExtraArgs = "--no-deps --document-private-items";
-					 RUSTDOCFLAGS="-Z unstable-options --enable-index-page";
-              }
-            );
-            workspace_fmt = craneLib.cargoFmt {
-              inherit src;
-              cargoExtraArgs = "--all";
-            };
-            kernel_aarch64_check = kernelAarch64Check;
-            loader_aarch64_uefi_check = loaderAarch64UefiCheck;
+            xtask = xtaskCheck;
           };
           devShells = {
             default = craneLib.devShell {

--- a/src/bin/xtask-check.rs
+++ b/src/bin/xtask-check.rs
@@ -1,0 +1,6 @@
+use {poison_girl::Xtask, poison_girl_dev_error::PoisonGirlB};
+
+fn main() -> PoisonGirlB<(),>
+{
+	Xtask::check()
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -13,6 +13,7 @@
 use {
 	crate::Xtask,
 	poison_girl_dev_cargo::Assets,
+	poison_girl_dev_cli::Run,
 	poison_girl_dev_error::{PoisonGirlB, X},
 	poison_girl_dev_orchestrate::{
 		CliCommandDiscriminants, Policy,
@@ -21,6 +22,7 @@ use {
 			workspace::WorkspaceAction,
 		},
 	},
+	std::process::Command,
 };
 
 impl Xtask
@@ -97,6 +99,72 @@ impl Xtask
 		}
 	}
 
+	/// Run every repository check used by CI.
+	///
+	/// This is the single source of truth for `nix flake check`; Nix only
+	/// supplies the toolchain, dependencies, and sandbox.
+	pub fn check() -> PoisonGirlB<(),>
+	{
+		run_cargo(&[
+			"metadata",
+			"--locked",
+			"--no-deps",
+			"--format-version",
+			"1",
+		],)?;
+		run_cargo(&["build", "--workspace", "--locked",],)?;
+		run_cargo(&[
+			"clippy",
+			"--workspace",
+			"--locked",
+			"--all-targets",
+			"--",
+			"-D",
+			"warnings",
+		],)?;
+		run_cargo(&[
+			"nextest",
+			"run",
+			"--workspace",
+			"--locked",
+			"--no-tests",
+			"pass",
+		],)?;
+
+		Command::new("cargo",)
+			.env(
+				"RUSTDOCFLAGS",
+				"-Z unstable-options --enable-index-page",
+			)
+			.args([
+				"doc",
+				"--workspace",
+				"--locked",
+				"--no-deps",
+				"--document-private-items",
+			],)
+			.run()?;
+
+		run_cargo(&["fmt", "--all", "--", "--check",],)?;
+		run_cargo(&[
+			"check",
+			"-p",
+			"poison_girl_kernel",
+			"--locked",
+			"--target",
+			"aarch64-unknown-none",
+		],)?;
+		run_cargo(&[
+			"check",
+			"-p",
+			"poison_girl_loader",
+			"--locked",
+			"--target",
+			"aarch64-unknown-uefi",
+		],)?;
+		X((),)
+	}
+
 	/// this is workspace build.
 	/// not a package build
 	fn build(&self,) -> PoisonGirlB<(),>
@@ -151,4 +219,9 @@ impl Xtask
 			.try_for_each(|at| self.ws().fix_at_with(at, args,),)?;
 		X((),)
 	}
+}
+
+fn run_cargo(args: &[&str],) -> PoisonGirlB<(),>
+{
+	Command::new("cargo",).args(args,).run()
 }


### PR DESCRIPTION
## What changed

- moved the existing repository check sequence into `Xtask::check`
- added an `xtask-check` binary and `cargo xt-check` alias
- replaced the individual Crane check derivations with one `xtaskCheck` derivation
- kept Crane responsible for the Rust toolchain, vendored dependencies, cached cargo artifacts, and the Nix sandbox

## Why

`flake.nix` duplicated the repository's build, clippy, test, documentation, formatting, metadata, and cross-target check policy. This makes xtask the single orchestration layer while keeping `nix flake check` as the CI entrypoint.

## Behavioral note

The former checks could build independently; the new xtask runner executes the same checks sequentially in one derivation. This trades per-check parallelism and granularity for one source of truth and shared target artifacts.

## Validation

Not run locally in this environment because Nix and the Rust toolchain are unavailable. The draft PR is intended to let the existing `nix flake check` workflow validate the sandboxed execution.